### PR TITLE
refresh: per-claim citation marker positions for 3 practice notes (#110)

### DIFF
--- a/practice-notes/bonus-compensation-new-york.json
+++ b/practice-notes/bonus-compensation-new-york.json
@@ -1,85 +1,85 @@
 {
-  "executive_summary": "In New York, a bonus dispute usually turns on classification, not label. The central question is whether the payment is discretionary incentive compensation outside Labor Law article 6, or earned, vested, non-discretionary compensation tied to the employee's own labor or services. If it is the latter, New York courts treat it as wages, which brings section 193 non-deduction rules and section 198 remedies into play. [[CITE:cite_75e129b4-d019-4cec-86af-22ec4ea7a70b]] [[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] [[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]]\n\nThe main control surface is the plan. Courts repeatedly ask who controls entitlement and amount, whether the payment depends on individual productivity or enterprise success, what event makes the bonus earned, and whether a continued-employment clause defines when the compensation is earned or instead operates as a forfeiture of pay already earned. The practical result is that New York bonus law is really a drafting-and-administration problem built on a stable doctrinal spine. [[CITE:cite_06c0911e-20a5-46a4-8cf8-ecd454185668]] [[CITE:cite_703ce749-75b6-403c-b14b-7d2fb852dd7b]] [[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]]",
-  "firm_consensus": "The strongest public sources and the selected firm commentary align on the same core point: New York does not treat every \"bonus\" alike. Orrick's Ryan write-up emphasizes that properly drafted discretionary bonus policies still work in New York, but only where the employer truly retained discretion and the bonus had not vested. RPJ's William Mattar note, like the case itself, treats a formulaic, earned, fee-based bonus very differently from a discretionary bonus because once the compensation is earned wages, a current-employment condition can fail as a matter of public policy. Proskauer's 2021 discussion adds the remedies overlay, explaining that New York's statutory amendments were aimed at making total nonpayment of allegedly owed wages and wage supplements actionable under sections 193 and 198 as well. [[CITE:cite_f63ad33a-7564-4513-8ac2-24bfae82f321]] [[CITE:cite_d3e3c8b9-47e6-48f2-ada3-ea2d9e55c4e5]] [[CITE:cite_a0adc158-a2a2-4f3e-b97c-d8fe67b80b0e]]\n\nThat consensus maps cleanly onto the primary authorities. Truelove remains the leading statement that discretionary, firm-success-linked incentive compensation is generally not wages. Ryan remains the leading Court of Appeals statement that a bonus expressly linked to services, and guaranteed and non-discretionary as a term of employment, can be wages. Kolchins, Doolittle, Gutt, and William Mattar all operate inside that same framework rather than displacing it. [[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] [[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] [[CITE:cite_06c0911e-20a5-46a4-8cf8-ecd454185668]] [[CITE:cite_703ce749-75b6-403c-b14b-7d2fb852dd7b]] [[CITE:cite_6aa077ce-0494-4e42-86d2-9d62a0aee689]] [[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]]",
-  "firm_differences": "The differences are mostly about emphasis, not doctrine. Orrick reads Ryan as a drafting lesson for employers: if the business wants discretion, the documents must actually reserve it, and at-will language by itself is not enough. Proskauer focuses on litigation posture and exposure after the 2021 amendments, especially the move away from the old argument that only a partial line-item deduction could trigger section 193. RPJ focuses on post-termination payout restrictions, using William Mattar to stress that a still-employed-on-the-payment-date requirement is not a safe back-end protection once the bonus is already earned and nondiscretionary. [[CITE:cite_f63ad33a-7564-4513-8ac2-24bfae82f321]] [[CITE:cite_a0adc158-a2a2-4f3e-b97c-d8fe67b80b0e]] [[CITE:cite_d3e3c8b9-47e6-48f2-ada3-ea2d9e55c4e5]]\n\nThat split in emphasis is useful for maintenance. It suggests the canonical page should stay narrow and doctrine-first, while recent-change monitoring should watch three distinct buckets: classification cases, post-termination forfeiture cases, and statutory or DOL developments affecting remedies or claim channels.",
+  "executive_summary": "In New York, a bonus dispute usually turns on classification, not label. The central question is whether the payment is discretionary incentive compensation outside Labor Law article 6,[[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] or earned, vested, non-discretionary compensation tied to the employee's own labor or services.[[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] If it is the latter, New York courts treat it as wages, which brings section 193 non-deduction rules and section 198 remedies into play.[[CITE:cite_75e129b4-d019-4cec-86af-22ec4ea7a70b]]\n\nThe main control surface is the plan. Courts repeatedly ask who controls entitlement and amount, whether the payment depends on individual productivity or enterprise success,[[CITE:cite_703ce749-75b6-403c-b14b-7d2fb852dd7b]] what event makes the bonus earned,[[CITE:cite_06c0911e-20a5-46a4-8cf8-ecd454185668]] and whether a continued-employment clause defines when the compensation is earned or instead operates as a forfeiture of pay already earned.[[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]] The practical result is that New York bonus law is really a drafting-and-administration problem built on a stable doctrinal spine.",
+  "firm_consensus": "The strongest public sources and the selected firm commentary align on the same core point: New York does not treat every \"bonus\" alike. Orrick's Ryan write-up emphasizes that properly drafted discretionary bonus policies still work in New York, but only where the employer truly retained discretion and the bonus had not vested.[[CITE:cite_f63ad33a-7564-4513-8ac2-24bfae82f321]] RPJ's William Mattar note, like the case itself, treats a formulaic, earned, fee-based bonus very differently from a discretionary bonus because once the compensation is earned wages, a current-employment condition can fail as a matter of public policy.[[CITE:cite_d3e3c8b9-47e6-48f2-ada3-ea2d9e55c4e5]] Proskauer's 2021 discussion adds the remedies overlay, explaining that New York's statutory amendments were aimed at making total nonpayment of allegedly owed wages and wage supplements actionable under sections 193 and 198 as well.[[CITE:cite_a0adc158-a2a2-4f3e-b97c-d8fe67b80b0e]]\n\nThat consensus maps cleanly onto the primary authorities. Truelove[[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] remains the leading statement that discretionary, firm-success-linked incentive compensation is generally not wages. Ryan[[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] remains the leading Court of Appeals statement that a bonus expressly linked to services, and guaranteed and non-discretionary as a term of employment, can be wages. Kolchins,[[CITE:cite_06c0911e-20a5-46a4-8cf8-ecd454185668]] Doolittle,[[CITE:cite_703ce749-75b6-403c-b14b-7d2fb852dd7b]] Gutt,[[CITE:cite_6aa077ce-0494-4e42-86d2-9d62a0aee689]] and William Mattar[[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]] all operate inside that same framework rather than displacing it.",
+  "firm_differences": "The differences are mostly about emphasis, not doctrine. Orrick reads Ryan as a drafting lesson for employers: if the business wants discretion, the documents must actually reserve it, and at-will language by itself is not enough.[[CITE:cite_f63ad33a-7564-4513-8ac2-24bfae82f321]] Proskauer focuses on litigation posture and exposure after the 2021 amendments, especially the move away from the old argument that only a partial line-item deduction could trigger section 193.[[CITE:cite_a0adc158-a2a2-4f3e-b97c-d8fe67b80b0e]] RPJ focuses on post-termination payout restrictions, using William Mattar to stress that a still-employed-on-the-payment-date requirement is not a safe back-end protection once the bonus is already earned and nondiscretionary.[[CITE:cite_d3e3c8b9-47e6-48f2-ada3-ea2d9e55c4e5]]\n\nThat split in emphasis is useful for maintenance. It suggests the canonical page should stay narrow and doctrine-first, while recent-change monitoring should watch three distinct buckets: classification cases, post-termination forfeiture cases, and statutory or DOL developments affecting remedies or claim channels.",
   "recent_developments": [
     {
       "date": "2025-05-02",
-      "event": "In Matter of William Mattar, P.C. v Riley, the Fourth Department held that an earned, fee-based, nondiscretionary bonus was wages, that failure to pay it violated section 193, and that a current-employee restriction could be void as against public policy. [[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]]"
+      "event": "In Matter of William Mattar, P.C. v Riley, the Fourth Department held that an earned, fee-based, nondiscretionary bonus was wages, that failure to pay it violated section 193, and that a current-employee restriction could be void as against public policy.[[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]]"
     },
     {
       "date": "2025-04-23",
-      "event": "In Gutt v North Am. Partners in Anesthesia, LLP, the Second Department held that bonus claims can still present triable issues where the bonus is tied in part to a revenue pool and the documents are ambiguous about discretion and implementation. [[CITE:cite_6aa077ce-0494-4e42-86d2-9d62a0aee689]]"
+      "event": "In Gutt v North Am. Partners in Anesthesia, LLP, the Second Department held that bonus claims can still present triable issues where the bonus is tied in part to a revenue pool and the documents are ambiguous about discretion and implementation.[[CITE:cite_6aa077ce-0494-4e42-86d2-9d62a0aee689]]"
     },
     {
       "date": "2024-03-13",
-      "event": "The New York Department of Labor raised the executive, administrative, and professional employee threshold for wage-supplement claims from $900 to $1,300 per week, which matters for agency complaint routes even though it does not erase contract or court remedies generally. [[CITE:cite_88cf957b-813c-4429-952b-5a792819cde9]] [[CITE:cite_ce90fb8d-cf11-4293-b543-6b2847986de5]]"
+      "event": "The New York Department of Labor raised the executive, administrative, and professional employee threshold for wage-supplement claims from $900 to $1,300 per week,[[CITE:cite_88cf957b-813c-4429-952b-5a792819cde9]] which matters for agency complaint routes even though it does not erase contract or court remedies generally.[[CITE:cite_ce90fb8d-cf11-4293-b543-6b2847986de5]]"
     },
     {
       "date": "2021-08-20",
-      "event": "New York enacted the No Wage Theft Loophole Act, adding matching language to sections 193 and 198 that there is no exception to liability for the unauthorized failure to pay wages, benefits, or wage supplements. [[CITE:cite_2d974e31-419e-4f96-8418-0e31ce86a858]] [[CITE:cite_e6afc38d-f8c7-4e18-8041-c02e7fef8cfe]] [[CITE:cite_a0adc158-a2a2-4f3e-b97c-d8fe67b80b0e]]"
+      "event": "New York enacted the No Wage Theft Loophole Act,[[CITE:cite_a0adc158-a2a2-4f3e-b97c-d8fe67b80b0e]] adding matching language to sections 193[[CITE:cite_2d974e31-419e-4f96-8418-0e31ce86a858]] and 198[[CITE:cite_e6afc38d-f8c7-4e18-8041-c02e7fef8cfe]] that there is no exception to liability for the unauthorized failure to pay wages, benefits, or wage supplements."
     }
   ],
   "questions": [
     {
       "id": "qa_c85b7592-c33a-44a4-917b-8a3a87b78ed3",
       "question": "What counts as \"wages\" for a New York bonus dispute?",
-      "answer": "New York Labor Law section 190 defines wages broadly as earnings for labor or services rendered, whether determined on a time, piece, commission, or other basis, and it also includes benefits or wage supplements for some article 6 purposes. [[CITE:cite_75e129b4-d019-4cec-86af-22ec4ea7a70b]] But bonus cases make clear that the broad definition still does not sweep in every incentive payment. The Court of Appeals in Truelove held that discretionary additional remuneration tied to the employer's financial success and allocated in the employer's sole discretion was outside article 6 wage protection. By contrast, Ryan held that a bonus expressly linked to the employee's own services, and guaranteed and non-discretionary as a term of employment, could be wages. [[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] [[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]]\n\nThe working rule for a maintained explainer should therefore be functional: a \"bonus\" can be wages if it behaves like compensation for the employee's own work and the employee has already satisfied the earning conditions. A \"bonus\" is less likely to be wages if it functions like a profit-sharing or retention incentive where the employer keeps meaningful discretion over whether anything is owed and how much is owed."
+      "answer": "New York Labor Law section 190 defines wages broadly as earnings for labor or services rendered, whether determined on a time, piece, commission, or other basis, and it also includes benefits or wage supplements for some article 6 purposes.[[CITE:cite_75e129b4-d019-4cec-86af-22ec4ea7a70b]] But bonus cases make clear that the broad definition still does not sweep in every incentive payment. The Court of Appeals in Truelove held that discretionary additional remuneration tied to the employer's financial success and allocated in the employer's sole discretion was outside article 6 wage protection.[[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] By contrast, Ryan held that a bonus expressly linked to the employee's own services, and guaranteed and non-discretionary as a term of employment, could be wages.[[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]]\n\nThe working rule for a maintained explainer should therefore be functional: a \"bonus\" can be wages if it behaves like compensation for the employee's own work and the employee has already satisfied the earning conditions. A \"bonus\" is less likely to be wages if it functions like a profit-sharing or retention incentive where the employer keeps meaningful discretion over whether anything is owed and how much is owed."
     },
     {
       "id": "qa_68a7a048-e4dc-4bef-bc15-841dcf6ca1f0",
       "question": "What is the core New York rule distinguishing discretionary bonuses from earned bonuses?",
-      "answer": "Truelove and Ryan remain the cleanest pairing. Truelove says compensation that depends on employer success and stays discretionary is not wages. Ryan says compensation becomes wages where it is expressly linked to labor or services personally rendered and is guaranteed and non-discretionary. Later cases do not replace that contrast; they apply it to harder fact patterns. [[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] [[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]]\n\nFor practical drafting and review, the key variables are:\n\n- whether the plan gives the employer discretion over entitlement, amount, or both\n- whether the payment formula tracks individual productivity, generated fees, or a defined threshold\n- whether the payment depends on the firm's overall profitability or another enterprise-level metric\n- whether the employee has already completed the services required to earn the payment\n\nIf those variables point toward vested compensation for completed services, New York courts are more willing to treat the payment as wages. If they point toward discretionary incentive compensation, the claim is much weaker under article 6. [[CITE:cite_703ce749-75b6-403c-b14b-7d2fb852dd7b]] [[CITE:cite_6aa077ce-0494-4e42-86d2-9d62a0aee689]] [[CITE:cite_ac95a068-6bc8-42e2-99a9-cc65d93fd475]]"
+      "answer": "Truelove and Ryan remain the cleanest pairing. Truelove[[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] says compensation that depends on employer success and stays discretionary is not wages. Ryan[[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] says compensation becomes wages where it is expressly linked to labor or services personally rendered and is guaranteed and non-discretionary. Later cases do not replace that contrast; they apply it to harder fact patterns.\n\nFor practical drafting and review, the key variables are:\n\n- whether the plan gives the employer discretion over entitlement, amount, or both\n- whether the payment formula tracks individual productivity, generated fees, or a defined threshold\n- whether the payment depends on the firm's overall profitability or another enterprise-level metric\n- whether the employee has already completed the services required to earn the payment\n\nIf those variables point toward vested compensation for completed services, New York courts are more willing to treat the payment as wages.[[CITE:cite_703ce749-75b6-403c-b14b-7d2fb852dd7b]][[CITE:cite_6aa077ce-0494-4e42-86d2-9d62a0aee689]] If they point toward discretionary incentive compensation, the claim is much weaker under article 6.[[CITE:cite_ac95a068-6bc8-42e2-99a9-cc65d93fd475]]"
     },
     {
       "id": "qa_dcdebd22-6337-4a2d-8e2b-baaf2091a73f",
       "question": "When does a bonus become earned or vested in New York?",
-      "answer": "The safest answer is that the plan controls unless the plan tries to withhold pay that New York law would treat as already earned wages. Ryan is the clearest Court of Appeals example that later payment timing does not by itself stop a bonus from being wages once it has already been earned and vested. Kolchins then sharpened the same point by refusing to treat a payout-date employment condition as dispositive where the production bonus may already have been earned wages. [[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] [[CITE:cite_06c0911e-20a5-46a4-8cf8-ecd454185668]]\n\nFor commission-like compensation, the Department of Labor's commission FAQ is especially useful because it states that a commission is earned at the time specified in the written agreement and, once earned, is legally considered wages. That makes agreement drafting on the earning event critical. The same logic carries over to bonus plans that look commission-like in operation even if they use the word \"bonus\". [[CITE:cite_7bd8b091-ac46-40c1-8a21-c174efdf5883]]"
+      "answer": "The safest answer is that the plan controls unless the plan tries to withhold pay that New York law would treat as already earned wages. Ryan[[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] is the clearest Court of Appeals example that later payment timing does not by itself stop a bonus from being wages once it has already been earned and vested. Kolchins[[CITE:cite_06c0911e-20a5-46a4-8cf8-ecd454185668]] then sharpened the same point by refusing to treat a payout-date employment condition as dispositive where the production bonus may already have been earned wages.\n\nFor commission-like compensation, the Department of Labor's commission FAQ is especially useful because it states that a commission is earned at the time specified in the written agreement and, once earned, is legally considered wages.[[CITE:cite_7bd8b091-ac46-40c1-8a21-c174efdf5883]] That makes agreement drafting on the earning event critical. The same logic carries over to bonus plans that look commission-like in operation even if they use the word \"bonus\"."
     },
     {
       "id": "qa_d5e6f4b9-0db3-4c9d-aafc-db1d89a7f867",
       "question": "Can an employer require the employee to still be employed on the payout date?",
-      "answer": "Sometimes yes, but not as a universal rule. Truelove allows continued-employment conditions where the payment is still discretionary incentive compensation outside article 6. Kolchins and William Mattar show the other side of the line: where compensation may already be earned wages, a current-employment condition can operate as an unlawful forfeiture and may be void as against public policy. [[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] [[CITE:cite_06c0911e-20a5-46a4-8cf8-ecd454185668]] [[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]]\n\nThe practical question is whether the continued-employment requirement is part of the definition of what must happen before the payment is earned, or whether it is really just a forfeiture mechanism attached to compensation already earned through completed work. William Mattar is particularly important because it applies that public-policy analysis to a fee-based bonus agreement in a modern, operationally realistic setting. [[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]] [[CITE:cite_d3e3c8b9-47e6-48f2-ada3-ea2d9e55c4e5]]"
+      "answer": "Sometimes yes, but not as a universal rule. Truelove[[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] allows continued-employment conditions where the payment is still discretionary incentive compensation outside article 6. Kolchins[[CITE:cite_06c0911e-20a5-46a4-8cf8-ecd454185668]] and William Mattar[[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]] show the other side of the line: where compensation may already be earned wages, a current-employment condition can operate as an unlawful forfeiture and may be void as against public policy.\n\nThe practical question is whether the continued-employment requirement is part of the definition of what must happen before the payment is earned, or whether it is really just a forfeiture mechanism attached to compensation already earned through completed work. William Mattar[[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]] is particularly important because it applies that public-policy analysis to a fee-based bonus agreement in a modern, operationally realistic setting.[[CITE:cite_d3e3c8b9-47e6-48f2-ada3-ea2d9e55c4e5]]"
     },
     {
       "id": "qa_6cc24512-b6e7-4226-a700-149e0547422a",
       "question": "What plan language best supports that a bonus is discretionary?",
-      "answer": "Two features matter most: explicit discretion and a structure that does not make the payment look like earned compensation for a defined unit of work. Hunter is a clean example that unambiguous contractual language making bonus awards solely and completely discretionary can defeat bonus claims. Orrick reads Ryan the same way from the drafting side: general at-will language is not enough, but real discretion language can still preserve a discretionary bonus regime. [[CITE:cite_ac95a068-6bc8-42e2-99a9-cc65d93fd475]] [[CITE:cite_f63ad33a-7564-4513-8ac2-24bfae82f321]]\n\nDoolittle is the important warning case on the other side. The Fourth Department said that unless an employer clearly indicates that bonuses are discretionary, the question whether unpaid incentive compensation is a discretionary bonus or earned wages not subject to forfeiture can remain a fact issue. A maintained note should therefore treat explicit discretion over entitlement and amount as a core drafting principle, not a stylistic preference. [[CITE:cite_703ce749-75b6-403c-b14b-7d2fb852dd7b]]"
+      "answer": "Two features matter most: explicit discretion and a structure that does not make the payment look like earned compensation for a defined unit of work. Hunter[[CITE:cite_ac95a068-6bc8-42e2-99a9-cc65d93fd475]] is a clean example that unambiguous contractual language making bonus awards solely and completely discretionary can defeat bonus claims. Orrick reads Ryan the same way from the drafting side: general at-will language is not enough, but real discretion language can still preserve a discretionary bonus regime.[[CITE:cite_f63ad33a-7564-4513-8ac2-24bfae82f321]]\n\nDoolittle[[CITE:cite_703ce749-75b6-403c-b14b-7d2fb852dd7b]] is the important warning case on the other side. The Fourth Department said that unless an employer clearly indicates that bonuses are discretionary, the question whether unpaid incentive compensation is a discretionary bonus or earned wages not subject to forfeiture can remain a fact issue. A maintained note should therefore treat explicit discretion over entitlement and amount as a core drafting principle, not a stylistic preference."
     },
     {
       "id": "qa_fdc27d2c-a945-48d5-b4b0-1e2e1e2d9245",
       "question": "What features tend to push a bonus toward wages?",
-      "answer": "Features that make the payment look mandatory, formulaic, and directly tied to the employee's own productivity push hardest toward wage status. Ryan involved an oral but allegedly guaranteed bonus tied to the employee's work. William Mattar involved bonus compensation calculated from actual gross receipts attributable to fees the employee generated. Gutt shows that even where a bonus pool has some profit-participation flavor, the wage question can remain live if the payment is tied in part to the employee's own revenue pool and the documents do not conclusively establish true discretion. [[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] [[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]] [[CITE:cite_6aa077ce-0494-4e42-86d2-9d62a0aee689]]\n\nOperationally, the risk signals are:\n\n- a fixed amount or fixed percentage\n- a threshold-based formula\n- payment measured by generated fees, sales, or collected revenue\n- language saying the employee \"shall\" receive the payment upon specified performance\n- weak or missing reservation of employer discretion\n\nThose signals do not make liability automatic, but they move the dispute toward the Ryan/Kolchins/William Mattar side of the line."
+      "answer": "Features that make the payment look mandatory, formulaic, and directly tied to the employee's own productivity push hardest toward wage status. Ryan[[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] involved an oral but allegedly guaranteed bonus tied to the employee's work. William Mattar[[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]] involved bonus compensation calculated from actual gross receipts attributable to fees the employee generated. Gutt[[CITE:cite_6aa077ce-0494-4e42-86d2-9d62a0aee689]] shows that even where a bonus pool has some profit-participation flavor, the wage question can remain live if the payment is tied in part to the employee's own revenue pool and the documents do not conclusively establish true discretion.\n\nOperationally, the risk signals are:\n\n- a fixed amount or fixed percentage\n- a threshold-based formula\n- payment measured by generated fees, sales, or collected revenue\n- language saying the employee \"shall\" receive the payment upon specified performance\n- weak or missing reservation of employer discretion\n\nThose signals do not make liability automatic, but they move the dispute toward the Ryan/Kolchins/William Mattar side of the line."
     },
     {
       "id": "qa_afcbb86a-0947-49a7-a810-0aadf4f05b5e",
       "question": "How does New York handle the commission-vs-bonus boundary?",
-      "answer": "The Department of Labor's commission FAQ gives a practical rule that is better than most generic bonus explainers. A true bonus exists where both the fact and amount of payment are wholly at the employer's discretion. If the employee is led to believe that hitting a stated level of orders or sales produces a stated amount of compensation, the DOL treats that as a commission instead. Once a commission is earned under the written agreement, it is wages and must be paid even after the employment relationship ends. [[CITE:cite_7bd8b091-ac46-40c1-8a21-c174efdf5883]] [[CITE:cite_75e129b4-d019-4cec-86af-22ec4ea7a70b]]\n\nThat boundary matters because many New York \"bonus\" disputes are really disputes about commission-like compensation or fee-based incentive pay. A page that does not call out that classification risk will miss a recurring source of drafting error."
+      "answer": "The Department of Labor's commission FAQ[[CITE:cite_7bd8b091-ac46-40c1-8a21-c174efdf5883]] gives a practical rule that is better than most generic bonus explainers. A true bonus exists where both the fact and amount of payment are wholly at the employer's discretion. If the employee is led to believe that hitting a stated level of orders or sales produces a stated amount of compensation, the DOL treats that as a commission instead. Once a commission is earned under the written agreement, it is wages and must be paid even after the employment relationship ends.[[CITE:cite_75e129b4-d019-4cec-86af-22ec4ea7a70b]]\n\nThat boundary matters because many New York \"bonus\" disputes are really disputes about commission-like compensation or fee-based incentive pay. A page that does not call out that classification risk will miss a recurring source of drafting error."
     },
     {
       "id": "qa_981f4bd2-c582-4750-809c-e7d6dab5c40c",
       "question": "What remedies drive risk if an earned bonus is withheld?",
-      "answer": "If the disputed compensation is wages, section 193's non-deduction rule and section 198's remedy provisions matter immediately. Section 198 provides for recovery of the underpayment, attorney's fees, prejudgment interest, and liquidated damages, and it preserves a six-year lookback for wages, benefits, and wage supplements. After the 2021 amendments, both sections 193 and 198 now say there is no exception to liability for the unauthorized failure to pay wages, benefits, or wage supplements. [[CITE:cite_2d974e31-419e-4f96-8418-0e31ce86a858]] [[CITE:cite_e6afc38d-f8c7-4e18-8041-c02e7fef8cfe]]\n\nProskauer's discussion is useful here because it isolates the post-2021 practical change: plaintiffs can frame some total-nonpayment disputes, including bonus disputes, as section 193 claims rather than being limited to the older \"partial deduction only\" view. That raises the leverage of classification fights because once the payment is treated as wages, fees and liquidated-damages exposure come with it. [[CITE:cite_a0adc158-a2a2-4f3e-b97c-d8fe67b80b0e]]"
+      "answer": "If the disputed compensation is wages, section 193's non-deduction rule[[CITE:cite_2d974e31-419e-4f96-8418-0e31ce86a858]] and section 198's remedy provisions matter immediately. Section 198 provides for recovery of the underpayment, attorney's fees, prejudgment interest, and liquidated damages, and it preserves a six-year lookback for wages, benefits, and wage supplements.[[CITE:cite_e6afc38d-f8c7-4e18-8041-c02e7fef8cfe]] After the 2021 amendments, both sections 193 and 198 now say there is no exception to liability for the unauthorized failure to pay wages, benefits, or wage supplements.\n\nProskauer's discussion is useful here because it isolates the post-2021 practical change: plaintiffs can frame some total-nonpayment disputes, including bonus disputes, as section 193 claims rather than being limited to the older \"partial deduction only\" view.[[CITE:cite_a0adc158-a2a2-4f3e-b97c-d8fe67b80b0e]] That raises the leverage of classification fights because once the payment is treated as wages, fees and liquidated-damages exposure come with it."
     },
     {
       "id": "qa_632a0653-5d6f-430a-818a-a1fe32bc0977",
       "question": "Can a bonus claim be taken to the New York Department of Labor?",
-      "answer": "Sometimes. The Department's wage-supplement page says it investigates unpaid wage-supplement claims where the employer promised, verbally or in writing, and failed to provide earned bonuses. But the same page says the Department will not accept commission claims from sales, and it also limits wage-supplement claims for bona fide executive, administrative, or professional employees earning more than $1,300 per week, effective March 13, 2024. [[CITE:cite_88cf957b-813c-4429-952b-5a792819cde9]] [[CITE:cite_ce90fb8d-cf11-4293-b543-6b2847986de5]]\n\nThat means the DOL route is useful but not universal. A maintained note should treat the DOL materials as practical enforcement guidance, not as the entire law of bonus recovery."
+      "answer": "Sometimes. The Department's wage-supplement page says it investigates unpaid wage-supplement claims where the employer promised, verbally or in writing, and failed to provide earned bonuses, but it will not accept commission claims from sales.[[CITE:cite_88cf957b-813c-4429-952b-5a792819cde9]] Labor Law section 198-c also limits wage-supplement claims for bona fide executive, administrative, or professional employees earning more than $1,300 per week, effective March 13, 2024.[[CITE:cite_ce90fb8d-cf11-4293-b543-6b2847986de5]]\n\nThat means the DOL route is useful but not universal. A maintained note should treat the DOL materials as practical enforcement guidance, not as the entire law of bonus recovery."
     },
     {
       "id": "qa_7b2e4f15-51f6-4f99-8066-93b52efaf893",
       "question": "What should employers and reviewers define first in a New York bonus plan?",
-      "answer": "Start with five items:\n\n- whether the employer retains discretion over entitlement, amount, or both\n- what precise event makes the payment earned\n- whether the payment is tied to individual productivity, firm performance, or both\n- how separation before payout is handled, and whether that clause is defining earning or attempting forfeiture\n- whether any commission-like compensation is being mislabeled as a bonus\n\nThe doctrinal through-line from Truelove to William Mattar shows why those are the right questions. New York bonus law is much less mysterious when the documents make the classification decision obvious up front; it becomes expensive when the documents blur the line between discretionary incentives and earned compensation for completed work. [[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] [[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] [[CITE:cite_06c0911e-20a5-46a4-8cf8-ecd454185668]] [[CITE:cite_703ce749-75b6-403c-b14b-7d2fb852dd7b]] [[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]]"
+      "answer": "Start with five items:\n\n- whether the employer retains discretion over entitlement, amount, or both\n- what precise event makes the payment earned\n- whether the payment is tied to individual productivity, firm performance, or both\n- how separation before payout is handled, and whether that clause is defining earning or attempting forfeiture\n- whether any commission-like compensation is being mislabeled as a bonus\n\nThe doctrinal through-line from Truelove[[CITE:cite_785f2e93-9bb4-4b44-af6d-2adacb481db3]] through Ryan,[[CITE:cite_a2686ce9-192a-464f-9163-1dae9e59337a]] Kolchins,[[CITE:cite_06c0911e-20a5-46a4-8cf8-ecd454185668]] and Doolittle[[CITE:cite_703ce749-75b6-403c-b14b-7d2fb852dd7b]] to William Mattar[[CITE:cite_b21d5ddc-1efc-4589-a059-e70752cc423c]] shows why those are the right questions. New York bonus law is much less mysterious when the documents make the classification decision obvious up front; it becomes expensive when the documents blur the line between discretionary incentives and earned compensation for completed work."
     }
   ],
   "references": [
     {
-      "id": "cite_75e129b4-d019-4cec-86af-22ec4ea7a70b",
-      "name": "New York State Senate",
-      "url": "https://www.nysenate.gov/legislation/laws/LAB/190",
-      "source_type": "statute",
-      "title": "Labor Law § 190",
-      "date": "2024-10-04"
+      "id": "cite_785f2e93-9bb4-4b44-af6d-2adacb481db3",
+      "name": "New York Court of Appeals",
+      "url": "https://law.justia.com/cases/new-york/court-of-appeals/2000/95-n-y-2d-220-0.html",
+      "source_type": "case_law",
+      "title": "Truelove v Northeast Capital & Advisory, Inc.",
+      "date": "2000-10-17"
     },
     {
       "id": "cite_a2686ce9-192a-464f-9163-1dae9e59337a",
@@ -90,20 +90,12 @@
       "date": "2012-03-27"
     },
     {
-      "id": "cite_785f2e93-9bb4-4b44-af6d-2adacb481db3",
-      "name": "New York Court of Appeals",
-      "url": "https://law.justia.com/cases/new-york/court-of-appeals/2000/95-n-y-2d-220-0.html",
-      "source_type": "case_law",
-      "title": "Truelove v Northeast Capital & Advisory, Inc.",
-      "date": "2000-10-17"
-    },
-    {
-      "id": "cite_06c0911e-20a5-46a4-8cf8-ecd454185668",
-      "name": "New York Court of Appeals",
-      "url": "https://www.nycourts.gov/Reporter/3dseries/2018/2018_02209.htm",
-      "source_type": "case_law",
-      "title": "Kolchins v Evolution Mkts., Inc.",
-      "date": "2018-03-29"
+      "id": "cite_75e129b4-d019-4cec-86af-22ec4ea7a70b",
+      "name": "New York State Senate",
+      "url": "https://www.nysenate.gov/legislation/laws/LAB/190",
+      "source_type": "statute",
+      "title": "Labor Law § 190",
+      "date": "2024-10-04"
     },
     {
       "id": "cite_703ce749-75b6-403c-b14b-7d2fb852dd7b",
@@ -112,6 +104,14 @@
       "source_type": "case_law",
       "title": "Doolittle v Nixon Peabody LLP",
       "date": "2015-03-27"
+    },
+    {
+      "id": "cite_06c0911e-20a5-46a4-8cf8-ecd454185668",
+      "name": "New York Court of Appeals",
+      "url": "https://www.nycourts.gov/Reporter/3dseries/2018/2018_02209.htm",
+      "source_type": "case_law",
+      "title": "Kolchins v Evolution Mkts., Inc.",
+      "date": "2018-03-29"
     },
     {
       "id": "cite_b21d5ddc-1efc-4589-a059-e70752cc423c",
@@ -326,6 +326,184 @@
       "url": "https://dol.ny.gov/payment-commissions-faq",
       "source_type": "agency_guidance",
       "title": "Payment of Commissions Frequently Asked Questions (FAQ)"
+    }
+  },
+  "_sources": {
+    "cite_6aa077ce-0494-4e42-86d2-9d62a0aee689": {
+      "source_ref": "cite_6aa077ce-0494-4e42-86d2-9d62a0aee689",
+      "url": "https://www.nycourts.gov/REPORTER/3dseries/2025/2025_02326.htm",
+      "source_type": "case_law",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "case_law"
+      }
+    },
+    "cite_ce90fb8d-cf11-4293-b543-6b2847986de5": {
+      "source_ref": "cite_ce90fb8d-cf11-4293-b543-6b2847986de5",
+      "url": "https://www.nysenate.gov/legislation/laws/LAB/198-C",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": "partial",
+        "source_class": "statute"
+      }
+    },
+    "cite_ac95a068-6bc8-42e2-99a9-cc65d93fd475": {
+      "source_ref": "cite_ac95a068-6bc8-42e2-99a9-cc65d93fd475",
+      "url": "https://law.justia.com/cases/new-york/appellate-division-first-department/2008/2008-08423.html",
+      "source_type": "case_law",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "case_law"
+      }
+    },
+    "cite_75e129b4-d019-4cec-86af-22ec4ea7a70b": {
+      "source_ref": "cite_75e129b4-d019-4cec-86af-22ec4ea7a70b",
+      "url": "https://www.nysenate.gov/legislation/laws/LAB/190",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
+    },
+    "cite_a2686ce9-192a-464f-9163-1dae9e59337a": {
+      "source_ref": "cite_a2686ce9-192a-464f-9163-1dae9e59337a",
+      "url": "https://www.nycourts.gov/Reporter/3dseries/2012/2012_02248.htm",
+      "source_type": "case_law",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "case_law"
+      }
+    },
+    "cite_7bd8b091-ac46-40c1-8a21-c174efdf5883": {
+      "source_ref": "cite_7bd8b091-ac46-40c1-8a21-c174efdf5883",
+      "url": "https://dol.ny.gov/payment-commissions-faq",
+      "source_type": "agency_guidance",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "agency_guidance"
+      }
+    },
+    "cite_b21d5ddc-1efc-4589-a059-e70752cc423c": {
+      "source_ref": "cite_b21d5ddc-1efc-4589-a059-e70752cc423c",
+      "url": "https://law.justia.com/cases/new-york/appellate-division-fourth-department/2025/192-ca-24-00464.html",
+      "source_type": "case_law",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "case_law"
+      }
+    },
+    "cite_f63ad33a-7564-4513-8ac2-24bfae82f321": {
+      "source_ref": "cite_f63ad33a-7564-4513-8ac2-24bfae82f321",
+      "url": "https://www.orrick.com/en/Insights/2012/05/The-New-York-Court-of-Appeals-Latest-Word-on-Bonus-Compensation-Disputes",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_a0adc158-a2a2-4f3e-b97c-d8fe67b80b0e": {
+      "source_ref": "cite_a0adc158-a2a2-4f3e-b97c-d8fe67b80b0e",
+      "url": "https://www.lawandtheworkplace.com/2021/09/new-york-labor-law-amendments-expand-scope-of-deductions-claims/",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": "partial",
+        "source_class": "firm_article"
+      }
+    },
+    "cite_06c0911e-20a5-46a4-8cf8-ecd454185668": {
+      "source_ref": "cite_06c0911e-20a5-46a4-8cf8-ecd454185668",
+      "url": "https://www.nycourts.gov/Reporter/3dseries/2018/2018_02209.htm",
+      "source_type": "case_law",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "case_law"
+      }
+    },
+    "cite_d3e3c8b9-47e6-48f2-ada3-ea2d9e55c4e5": {
+      "source_ref": "cite_d3e3c8b9-47e6-48f2-ada3-ea2d9e55c4e5",
+      "url": "https://rpjlaw.com/recent-new-york-case-precedent-regarding-an-employees-right-to-bonus-payments-following-termination-of-employment/",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_785f2e93-9bb4-4b44-af6d-2adacb481db3": {
+      "source_ref": "cite_785f2e93-9bb4-4b44-af6d-2adacb481db3",
+      "url": "https://law.justia.com/cases/new-york/court-of-appeals/2000/95-n-y-2d-220-0.html",
+      "source_type": "case_law",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "case_law"
+      }
+    },
+    "cite_2d974e31-419e-4f96-8418-0e31ce86a858": {
+      "source_ref": "cite_2d974e31-419e-4f96-8418-0e31ce86a858",
+      "url": "https://www.nysenate.gov/legislation/laws/LAB/193",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
+    },
+    "cite_703ce749-75b6-403c-b14b-7d2fb852dd7b": {
+      "source_ref": "cite_703ce749-75b6-403c-b14b-7d2fb852dd7b",
+      "url": "https://www.nycourts.gov/REPORTER/3dseries/2015/2015_02630.htm",
+      "source_type": "case_law",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "case_law"
+      }
+    },
+    "cite_88cf957b-813c-4429-952b-5a792819cde9": {
+      "source_ref": "cite_88cf957b-813c-4429-952b-5a792819cde9",
+      "url": "https://dol.ny.gov/unpaidwithheld-wages-and-wage-supplements",
+      "source_type": "agency_guidance",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "agency_guidance"
+      }
+    },
+    "cite_e6afc38d-f8c7-4e18-8041-c02e7fef8cfe": {
+      "source_ref": "cite_e6afc38d-f8c7-4e18-8041-c02e7fef8cfe",
+      "url": "https://www.nysenate.gov/legislation/laws/LAB/198",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
     }
   },
   "_metadata": {

--- a/practice-notes/non-compete-wyoming.json
+++ b/practice-notes/non-compete-wyoming.json
@@ -1,52 +1,52 @@
 {
-  "executive_summary": "Wyoming now has a two-track non-compete regime. For contracts entered into on or after July 1, 2025, Senate File 107, codified at W.S. 1-23-108, voids any covenant not to compete that restricts the right of any person to receive compensation for skilled or unskilled labor, subject only to four listed exceptions: sale-of-business covenants, trade-secret protection, capped expense-recovery provisions, and covenants for executive and management personnel and their professional staff. The same enactment separately voids physician non-compete provisions and protects disclosure of new contact information to patients with rare disorders. [[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] [[CITE:cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7]] [[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]]\n\nPre-July 1, 2025 agreements were not retroactively voided, but they were not made easy to enforce either. Wyoming common law already treated non-competes as presumptively invalid restraints on trade, placed the burden on the employer to justify them, required reasonable consideration, and after *Hassler* forbade courts from blue-penciling unreasonable covenants to save them. *Brown* also confirms that continued employment alone is not sufficient consideration when an existing employee is asked to sign later. [[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] [[CITE:cite_988adf21-88d4-489f-8f57-0443a9491376]] [[CITE:cite_abcd3429-ed74-45a0-b034-4555f6f9a241]] [[CITE:cite_a6264d6f-b101-4b22-b639-17d61d96c7f5]]\n\nThe remaining Wyoming questions are interpretive, not structural. State-specific firm analyses broadly read the statute's \"any person\" language to reach independent contractors as well as employees, but they also emphasize that Wyoming courts still have not defined the executive-and-management personnel category or resolved whether customer nonsolicits, employee nonsolicits, broad confidentiality clauses, or similar restraints will be treated as prohibited covenants not to compete. [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] [[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]] [[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]",
-  "firm_consensus": "Ogletree, Littler, Faegre, Fisher Phillips, and Holland & Hart all read SF 107 as a major narrowing of Wyoming practice, not a minor adjustment. They agree that the statute is prospective only, that the four statutory exceptions are the operative post-July 1, 2025 carveouts, and that physician non-competes are separately voided by subsection (b). They also agree that employers cannot assume old template language will survive a simple rollover after the effective date. [[CITE:cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7]] [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] [[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]] [[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]\n\nThose firm analyses also sit on top of a demanding Wyoming case-law baseline. *Brown* and *Malave* describe non-competes as restraints that are strictly construed, and *Hassler* makes drafting error much more expensive by eliminating blue-penciling. So even where a restraint arguably fits a statutory exception, Wyoming-specific commentary does not treat that as a license for careless drafting. [[CITE:cite_988adf21-88d4-489f-8f57-0443a9491376]] [[CITE:cite_abcd3429-ed74-45a0-b034-4555f6f9a241]] [[CITE:cite_a6264d6f-b101-4b22-b639-17d61d96c7f5]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]",
-  "firm_differences": "The sharpest source-level disagreement is over adjacent restraints. Brownstein takes the most employer-friendly view and says the statute does not affect non-solicitation, non-recruitment, or confidentiality agreements. Littler and Fisher Phillips are more cautious: Littler says the lack of an express non-solicit exception leaves the issue unclear, and Fisher says courts still must decide whether customer nonsolicits, employee nonsolicits, broad confidentiality provisions, or anti-moonlighting clauses count as covered non-compete covenants under the new language. The safest Wyoming-specific synthesis is uncertainty, not a blanket rule of safety. [[CITE:cite_39244c4c-0e56-4cc2-b848-51bb57d56bbb]] [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] [[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]]\n\nThe firms also vary in how aggressively they use Colorado analogies for the executive-and-management exception. Fisher Phillips and Holland & Hart develop Colorado comparisons in some detail, while Faegre and Littler mainly emphasize the absence of Wyoming definitions. The common denominator is narrower: titles alone are not enough, and any future Wyoming analysis is likely to focus on actual authority, autonomy, and managerial function. [[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]] [[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]] [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]]\n\nFinally, the physician subsection raises a textual edge the sources handle cautiously. Littler and Holland & Hart both note that subsection (b) speaks of agreements \"between physicians,\" which can create a question about contracts with hospitals or other non-physician entities. The note therefore treats the physician carveout's application beyond the statutory text as unsettled rather than overstating certainty. [[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]",
+  "executive_summary": "Wyoming now has a two-track non-compete regime. For contracts entered into on or after July 1, 2025, Senate File 107, codified at W.S. 1-23-108, voids any covenant not to compete that restricts the right of any person to receive compensation for skilled or unskilled labor, subject only to four listed exceptions: sale-of-business covenants, trade-secret protection, capped expense-recovery provisions, and covenants for executive and management personnel and their professional staff.[[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] The same enactment separately voids physician non-compete provisions and protects disclosure of new contact information to patients with rare disorders.[[CITE:cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7]][[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]]\n\nPre-July 1, 2025 agreements were not retroactively voided,[[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] but they were not made easy to enforce either. Wyoming common law already treated non-competes as presumptively invalid restraints on trade, placed the burden on the employer to justify them, and required reasonable consideration,[[CITE:cite_abcd3429-ed74-45a0-b034-4555f6f9a241]] and after *Hassler* forbade courts from blue-penciling unreasonable covenants to save them.[[CITE:cite_a6264d6f-b101-4b22-b639-17d61d96c7f5]] *Brown* also confirms that continued employment alone is not sufficient consideration when an existing employee is asked to sign later.[[CITE:cite_988adf21-88d4-489f-8f57-0443a9491376]]\n\nThe remaining Wyoming questions are interpretive, not structural. State-specific firm analyses broadly read the statute's \"any person\" language to reach independent contractors as well as employees,[[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]][[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]] but they also emphasize that Wyoming courts still have not defined the executive-and-management personnel category or resolved whether customer nonsolicits, employee nonsolicits, broad confidentiality clauses, or similar restraints will be treated as prohibited covenants not to compete.[[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]][[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]",
+  "firm_consensus": "Ogletree,[[CITE:cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7]] Littler,[[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] Faegre,[[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]] Fisher Phillips,[[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] and Holland & Hart[[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]] all read SF 107 as a major narrowing of Wyoming practice, not a minor adjustment. They agree that the statute is prospective only, that the four statutory exceptions are the operative post-July 1, 2025 carveouts, and that physician non-competes are separately voided by subsection (b). They also agree that employers cannot assume old template language will survive a simple rollover after the effective date.\n\nThose firm analyses also sit on top of a demanding Wyoming case-law baseline. *Brown*[[CITE:cite_988adf21-88d4-489f-8f57-0443a9491376]] and *Malave*[[CITE:cite_abcd3429-ed74-45a0-b034-4555f6f9a241]] describe non-competes as restraints that are strictly construed, and *Hassler*[[CITE:cite_a6264d6f-b101-4b22-b639-17d61d96c7f5]] makes drafting error much more expensive by eliminating blue-penciling. So even where a restraint arguably fits a statutory exception, Wyoming-specific commentary does not treat that as a license for careless drafting.[[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]",
+  "firm_differences": "The sharpest source-level disagreement is over adjacent restraints. Brownstein takes the most employer-friendly view and says the statute does not affect non-solicitation, non-recruitment, or confidentiality agreements.[[CITE:cite_39244c4c-0e56-4cc2-b848-51bb57d56bbb]] Littler and Fisher Phillips are more cautious: Littler says the lack of an express non-solicit exception leaves the issue unclear,[[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] and Fisher says courts still must decide whether customer nonsolicits, employee nonsolicits, broad confidentiality provisions, or anti-moonlighting clauses count as covered non-compete covenants under the new language.[[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] The safest Wyoming-specific synthesis is uncertainty, not a blanket rule of safety.\n\nThe firms also vary in how aggressively they use Colorado analogies for the executive-and-management exception. Fisher Phillips and Holland & Hart develop Colorado comparisons in some detail,[[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]][[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]] while Faegre and Littler mainly emphasize the absence of Wyoming definitions.[[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]][[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] The common denominator is narrower: titles alone are not enough, and any future Wyoming analysis is likely to focus on actual authority, autonomy, and managerial function.\n\nFinally, the physician subsection raises a textual edge the sources handle cautiously. Subsection (b) speaks of agreements \"between physicians,\"[[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] which Littler and Holland & Hart both note can create a question about contracts with hospitals or other non-physician entities.[[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]][[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]] The note therefore treats the physician carveout's application beyond the statutory text as unsettled rather than overstating certainty.",
   "recent_developments": [
     {
       "date": "July 1, 2025",
-      "event": "The new statute took effect for contracts entered into on and after that date, while the act expressly left earlier contracts untouched. [[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] [[CITE:cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7]]"
+      "event": "The new statute took effect for contracts entered into on and after that date,[[CITE:cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7]] while the act expressly left earlier contracts untouched.[[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]]"
     },
     {
       "date": "March 19, 2025",
-      "event": "Governor Mark Gordon signed Senate File 107, creating W.S. 1-23-108 and replacing Wyoming's prior statute-free regime with a broad prospective ban plus enumerated exceptions. [[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]]"
+      "event": "Governor Mark Gordon signed Senate File 107, creating W.S. 1-23-108 and replacing Wyoming's prior statute-free regime with a broad prospective ban plus enumerated exceptions.[[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]]"
     }
   ],
   "questions": [
     {
       "id": "qa_1a57c818-09ed-432a-b3a2-979d509b904f",
       "question": "Are employee non-compete agreements enforceable in Wyoming?",
-      "answer": "For contracts entered into on or after July 1, 2025, usually no. W.S. 1-23-108(a) says any covenant not to compete that restricts the right of any person to receive compensation for skilled or unskilled labor is void unless it fits one of four statutory exceptions. Ogletree, Faegre, Littler, Fisher Phillips, and Holland & Hart all describe that as a broad ban rather than a narrow drafting rule. [[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] [[CITE:cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7]] [[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]] [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] [[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]\n\nBecause the statute applies to \"any person,\" Wyoming-specific firm analyses also read it broadly enough to reach independent contractors, not only employees. That remains an interpretation rather than a Wyoming appellate holding, but it is the dominant state-specific reading in the 2025 firm commentary. [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] [[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]] [[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]"
+      "answer": "For contracts entered into on or after July 1, 2025, usually no. W.S. 1-23-108(a) says any covenant not to compete that restricts the right of any person to receive compensation for skilled or unskilled labor is void unless it fits one of four statutory exceptions.[[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] Ogletree,[[CITE:cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7]] Faegre,[[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]] Littler,[[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] Fisher Phillips,[[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] and Holland & Hart[[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]] all describe that as a broad ban rather than a narrow drafting rule.\n\nBecause the statute applies to \"any person,\" Wyoming-specific firm analyses also read it broadly enough to reach independent contractors, not only employees.[[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]][[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]][[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]][[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]] That remains an interpretation rather than a Wyoming appellate holding, but it is the dominant state-specific reading in the 2025 firm commentary."
     },
     {
       "id": "qa_1f62d2c8-06a4-43b2-a14b-bf476cc2f1a6",
       "question": "What law governs agreements signed before July 1, 2025?",
-      "answer": "Section 2(b) of the 2025 act says nothing in the statute alters, amends, or impairs contracts entered into before July 1, 2025, so older covenants continue to be judged under Wyoming common law rather than the new statutory ban. [[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]]\n\nThat older framework is still demanding. *Malave* restates the traditional Wyoming elements: the covenant must be in writing, part of a contract of employment, supported by reasonable consideration, reasonable in duration and geography, and not against public policy. *Brown* and *Malave* also emphasize that Wyoming strictly construes non-competes and puts the burden on the employer to prove special circumstances making the restraint reasonably necessary. For post-hire covenants, *Brown* says continued employment alone is insufficient consideration; the employer must provide separate contemporaneous consideration. [[CITE:cite_988adf21-88d4-489f-8f57-0443a9491376]] [[CITE:cite_abcd3429-ed74-45a0-b034-4555f6f9a241]]"
+      "answer": "Section 2(b) of the 2025 act says nothing in the statute alters, amends, or impairs contracts entered into before July 1, 2025, so older covenants continue to be judged under Wyoming common law rather than the new statutory ban.[[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]]\n\nThat older framework is still demanding. *Malave*[[CITE:cite_abcd3429-ed74-45a0-b034-4555f6f9a241]] restates the traditional Wyoming elements: the covenant must be in writing, part of a contract of employment, supported by reasonable consideration, reasonable in duration and geography, and not against public policy. *Brown*[[CITE:cite_988adf21-88d4-489f-8f57-0443a9491376]] and *Malave* also emphasize that Wyoming strictly construes non-competes and puts the burden on the employer to prove special circumstances making the restraint reasonably necessary. For post-hire covenants, *Brown* says continued employment alone is insufficient consideration; the employer must provide separate contemporaneous consideration."
     },
     {
       "id": "qa_0ff119ba-f449-4fdc-98b9-d044b0efdb20",
       "question": "Can Wyoming courts blue-pencil or narrow an overbroad covenant?",
-      "answer": "No. In *Hassler*, the Wyoming Supreme Court held that the blue-pencil rule is no longer permitted to make non-compete agreements reasonable, overruled *Hopper* on that point, and concluded that the entire agreement there was void because its duration and geography were unreasonable. [[CITE:cite_a6264d6f-b101-4b22-b639-17d61d96c7f5]]\n\nThat matters both for legacy agreements and for post-2025 agreements that try to fit an exception. Wyoming-specific commentary warns employers not to assume a court will rescue overbroad drafting by trimming it back later. [[CITE:cite_a6264d6f-b101-4b22-b639-17d61d96c7f5]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]"
+      "answer": "No. In *Hassler*,[[CITE:cite_a6264d6f-b101-4b22-b639-17d61d96c7f5]] the Wyoming Supreme Court held that the blue-pencil rule is no longer permitted to make non-compete agreements reasonable, overruled *Hopper* on that point, and concluded that the entire agreement there was void because its duration and geography were unreasonable.\n\nThat matters both for legacy agreements and for post-2025 agreements that try to fit an exception.[[CITE:cite_a6264d6f-b101-4b22-b639-17d61d96c7f5]] Wyoming-specific commentary warns employers not to assume a court will rescue overbroad drafting by trimming it back later.[[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]"
     },
     {
       "id": "qa_0dd353e7-5a41-4f5e-92a9-de45a43d600e",
       "question": "What restrictions remain available after July 1, 2025?",
-      "answer": "The statute leaves four categories in play: sale-of-business covenants, covenants protecting trade secrets as defined by W.S. 6-3-501(a)(xi), capped repayment provisions for relocation, education, and training expense, and covenants with executive and management personnel and their professional staff. The expense-recovery schedule is fixed by tenure: up to 100% for service under two years, up to 66% for between two and less than three years, and up to 33% for between three and less than four years. [[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] [[CITE:cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7]] [[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]]\n\nEven inside those exceptions, the Wyoming-specific commentary does not treat enforcement as automatic. Holland & Hart warns that Wyoming employers still need a legitimate business fit and reasonable drafting, while Littler says the practical breadth of the trade-secret exception remains uncertain and may depend on how courts understand the relationship between trade-secret protection and post-employment restraint. [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]] [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]]"
+      "answer": "The statute leaves four categories in play: sale-of-business covenants, covenants protecting trade secrets as defined by W.S. 6-3-501(a)(xi), capped repayment provisions for relocation, education, and training expense, and covenants with executive and management personnel and their professional staff.[[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]] The expense-recovery schedule is fixed by tenure: up to 100% for service under two years, up to 66% for between two and less than three years, and up to 33% for between three and less than four years.[[CITE:cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7]][[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]]\n\nEven inside those exceptions, the Wyoming-specific commentary does not treat enforcement as automatic. Holland & Hart warns that Wyoming employers still need a legitimate business fit and reasonable drafting,[[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]] while Littler says the practical breadth of the trade-secret exception remains uncertain and may depend on how courts understand the relationship between trade-secret protection and post-employment restraint.[[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]]"
     },
     {
       "id": "qa_395c84d1-83d8-4e32-8351-6d12026f72cf",
       "question": "Are customer nonsolicitation, employee nonsolicitation, and confidentiality clauses safe in Wyoming?",
-      "answer": "Not clearly. The statute does not expressly exempt non-solicits. Brownstein reads the act as leaving non-solicitation, non-recruitment, and confidentiality agreements intact. Littler and Fisher Phillips take a more cautious view: Littler says the absence of a non-solicit exception leaves the point unclear, and Fisher says courts still must decide whether customer nonsolicits, employee nonsolicits, broad confidentiality provisions, or anti-moonlighting clauses are really prohibited non-compete covenants under the new text. [[CITE:cite_39244c4c-0e56-4cc2-b848-51bb57d56bbb]] [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] [[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]]\n\nBecause the statute is silent and the source set is not unanimous, the safer Wyoming-specific conclusion is that narrow nonsolicits and confidentiality covenants may still be used, but their status is unsettled if they function as de facto non-competes. [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] [[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] [[CITE:cite_39244c4c-0e56-4cc2-b848-51bb57d56bbb]]"
+      "answer": "Not clearly. The statute does not expressly exempt non-solicits. Brownstein reads the act as leaving non-solicitation, non-recruitment, and confidentiality agreements intact.[[CITE:cite_39244c4c-0e56-4cc2-b848-51bb57d56bbb]] Littler and Fisher Phillips take a more cautious view: Littler says the absence of a non-solicit exception leaves the point unclear,[[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] and Fisher says courts still must decide whether customer nonsolicits, employee nonsolicits, broad confidentiality provisions, or anti-moonlighting clauses are really prohibited non-compete covenants under the new text.[[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]]\n\nBecause the statute is silent and the source set is not unanimous, the safer Wyoming-specific conclusion is that narrow nonsolicits and confidentiality covenants may still be used,[[CITE:cite_39244c4c-0e56-4cc2-b848-51bb57d56bbb]] but their status is unsettled if they function as de facto non-competes.[[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]][[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]]"
     },
     {
       "id": "qa_4ad5e7c2-d0bb-44cf-93fc-75d87d57a7bf",
       "question": "What special rules apply to physicians in Wyoming?",
-      "answer": "Section 1-23-108(b) separately voids any covenant not to compete provision of an employment, partnership, or corporate agreement between physicians that restricts the right of a physician to practice medicine upon termination, while leaving the rest of the agreement enforceable if otherwise valid. Section 1-23-108(c) then allows a departing physician to disclose continuing practice and new professional contact information to rare-disorder patients without liability to the prior counterparty. [[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]]\n\nThe hard part is the phrase \"between physicians.\" Littler and Holland & Hart both note that this wording creates a textual question about contracts with hospitals or other non-physician entities, so the cleaner statement is that Wyoming clearly voids physician-to-physician practice restraints and leaves the outer edge of physician-employer application less certain. [[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]"
+      "answer": "Section 1-23-108(b) separately voids any covenant not to compete provision of an employment, partnership, or corporate agreement between physicians that restricts the right of a physician to practice medicine upon termination, while leaving the rest of the agreement enforceable if otherwise valid. Section 1-23-108(c) then allows a departing physician to disclose continuing practice and new professional contact information to rare-disorder patients without liability to the prior counterparty.[[CITE:cite_6bea5e33-857a-401d-bbfc-dbc79024265e]]\n\nThe hard part is the phrase \"between physicians.\" Littler and Holland & Hart both note that this wording creates a textual question about contracts with hospitals or other non-physician entities,[[CITE:cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1]][[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]] so the cleaner statement is that Wyoming clearly voids physician-to-physician practice restraints and leaves the outer edge of physician-employer application less certain."
     },
     {
       "id": "qa_5d3c055d-8c7c-4814-91aa-8b7d4a8f5808",
       "question": "Who qualifies as executive or management personnel in Wyoming?",
-      "answer": "The statute does not define executive, management, professional staff, or the combined executive-and-management personnel category. Faegre flags that drafting gap directly, and Fisher Phillips and Holland & Hart both say Colorado cases construing nearly identical older statutory language may offer nonbinding guidance. [[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]] [[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]\n\nThose sources focus on actual responsibilities rather than titles alone. The recurring factors are supervision, autonomy, hiring or firing authority, and whether the employee plays a meaningful role in implementing executive or management functions. Until Wyoming courts speak directly, that function-over-title approach is the most defensible reading. [[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]] [[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]"
+      "answer": "The statute does not define executive, management, professional staff, or the combined executive-and-management personnel category. Faegre flags that drafting gap directly,[[CITE:cite_ecb401c7-3646-47c5-b7b7-a00cd4571171]] and Fisher Phillips and Holland & Hart both say Colorado cases construing nearly identical older statutory language may offer nonbinding guidance.[[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]][[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]]\n\nThose sources focus on actual responsibilities rather than titles alone.[[CITE:cite_f9ff7411-d73d-493f-9cf5-671550d81383]][[CITE:cite_6d928bb1-aeca-490c-8766-95973411634d]] The recurring factors are supervision, autonomy, hiring or firing authority, and whether the employee plays a meaningful role in implementing executive or management functions. Until Wyoming courts speak directly, that function-over-title approach is the most defensible reading."
     }
   ],
   "references": [
@@ -75,14 +75,6 @@
       "date": "2025-03-21"
     },
     {
-      "id": "cite_988adf21-88d4-489f-8f57-0443a9491376",
-      "name": "Supreme Court of Wyoming on Justia",
-      "url": "https://law.justia.com/cases/wyoming/supreme-court/2021/s-20-0270.html",
-      "source_type": "case_law",
-      "title": "Brown v. Best Home Health & Hospice, LLC",
-      "date": "2021-07-15"
-    },
-    {
       "id": "cite_abcd3429-ed74-45a0-b034-4555f6f9a241",
       "name": "Supreme Court of Wyoming on Justia",
       "url": "https://law.justia.com/cases/wyoming/supreme-court/2022/s-21-0140.html",
@@ -97,6 +89,14 @@
       "source_type": "case_law",
       "title": "Hassler v. Circle C Resources",
       "date": "2022-02-25"
+    },
+    {
+      "id": "cite_988adf21-88d4-489f-8f57-0443a9491376",
+      "name": "Supreme Court of Wyoming on Justia",
+      "url": "https://law.justia.com/cases/wyoming/supreme-court/2021/s-20-0270.html",
+      "source_type": "case_law",
+      "title": "Brown v. Best Home Health & Hospice, LLC",
+      "date": "2021-07-15"
     },
     {
       "id": "cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1",
@@ -211,6 +211,118 @@
       "source_type": "law_firm_commentary",
       "title": "Wyoming Adopts Statutory Limits for Noncompetes",
       "date": "2025-05-14"
+    }
+  },
+  "_sources": {
+    "cite_988adf21-88d4-489f-8f57-0443a9491376": {
+      "source_ref": "cite_988adf21-88d4-489f-8f57-0443a9491376",
+      "url": "https://law.justia.com/cases/wyoming/supreme-court/2021/s-20-0270.html",
+      "source_type": "case_law",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "case"
+      }
+    },
+    "cite_a6264d6f-b101-4b22-b639-17d61d96c7f5": {
+      "source_ref": "cite_a6264d6f-b101-4b22-b639-17d61d96c7f5",
+      "url": "https://law.justia.com/cases/wyoming/supreme-court/2022/s-21-0132.html",
+      "source_type": "case_law",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "case"
+      }
+    },
+    "cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1": {
+      "source_ref": "cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1",
+      "url": "https://www.littler.com/publication-press/publication/wyoming-bans-non-compete-covenants-some-exceptions",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_ecb401c7-3646-47c5-b7b7-a00cd4571171": {
+      "source_ref": "cite_ecb401c7-3646-47c5-b7b7-a00cd4571171",
+      "url": "https://www.faegredrinker.com/en/insights/publications/2025/3/wyoming-enacts-significant-restrictions-on-noncompete-agreements",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_6bea5e33-857a-401d-bbfc-dbc79024265e": {
+      "source_ref": "cite_6bea5e33-857a-401d-bbfc-dbc79024265e",
+      "url": "https://wyoleg.gov/2025/Enroll/SF0107.pdf",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
+    },
+    "cite_39244c4c-0e56-4cc2-b848-51bb57d56bbb": {
+      "source_ref": "cite_39244c4c-0e56-4cc2-b848-51bb57d56bbb",
+      "url": "https://www.bhfs.com/insights/alerts-articles/2025/wyoming-adopts-statutory-limits-for-noncompetes",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_f9ff7411-d73d-493f-9cf5-671550d81383": {
+      "source_ref": "cite_f9ff7411-d73d-493f-9cf5-671550d81383",
+      "url": "https://www.fisherphillips.com/en/news-insights/new-law-voids-most-wyoming-non-compete-agreements.html",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_6d928bb1-aeca-490c-8766-95973411634d": {
+      "source_ref": "cite_6d928bb1-aeca-490c-8766-95973411634d",
+      "url": "https://www.hollandhart.com/wyoming-legislature-takes-a-bite-out-of-covenants-not-to-compete-1",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7": {
+      "source_ref": "cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7",
+      "url": "https://ogletree.com/insights-resources/blog-posts/wyoming-enacts-law-to-restrict-the-use-of-noncompete-agreements/",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_abcd3429-ed74-45a0-b034-4555f6f9a241": {
+      "source_ref": "cite_abcd3429-ed74-45a0-b034-4555f6f9a241",
+      "url": "https://law.justia.com/cases/wyoming/supreme-court/2022/s-21-0140.html",
+      "source_type": "case_law",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "case"
+      }
     }
   },
   "_metadata": {

--- a/practice-notes/startup-sale-delaware-startup-stock-purchase-agreement.json
+++ b/practice-notes/startup-sale-delaware-startup-stock-purchase-agreement.json
@@ -1,61 +1,61 @@
 {
-  "executive_summary": "This note is about drafting a stock purchase agreement for the acquisition of a Delaware-incorporated venture-backed startup. It is not a general private-M&A survey and it is not a merger-agreement note. The maintainable core is narrower: start with orthodox SPA architecture, then tailor it around the startup document stack that actually governs the target, including charter rights, investor agreements, transfer restrictions, SAFEs or notes, employee equity, and software-driven product risk. [[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]][[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]][[CITE:cite_35580cae-b796-4761-bf2f-7ca95686c1c5]]\n\nGeneric private-company precedent usually breaks first on structure, capitalization math, and rep-and-schedule design. Delaware law makes clear that stock transfers, mergers, and asset sales do not operate the same way, and startup sources show why venture-backed targets add a second layer of drafting complexity on top of that baseline. A useful startup SPA note should therefore stay focused on the drafting issues that repeatedly change the agreement itself: structure, approvals, cap table treatment, startup-specific reps and schedules, and post-closing risk allocation. [[CITE:cite_295fc761-1908-4708-9c6f-f7438e6f1e7d]][[CITE:cite_5da1edaf-1356-4497-bba9-e3db327a5545]][[CITE:cite_5747d905-71c4-4b66-b6b2-41d4cc55029d]][[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]][[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]]",
-  "firm_consensus": "The strongest public practitioner sources converge on a simple point: a startup SPA should not be drafted as if it were merely a shorter version of a generic private-company purchase agreement. The ABA's new Model Short SPA is explicit that even a modern public drafting aid is only a starting point for experienced counsel and must be tailored to the target, industry, and transaction. Cooley, Pillsbury, and Davis Polk each identify startup-specific drafting pressure points that standard forms routinely miss, while SRS Acquiom's current deal-terms work reinforces that indemnity, escrow, earnout, and insurance architecture still turn on transaction-specific design rather than folklore about what is supposedly \"market.\" [[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]][[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]][[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]][[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]][[CITE:cite_2a018b66-6589-45d7-845d-b091d8b11884]][[CITE:cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48]]\n\nThe same sources also support a more startup-specific consensus: before the SPA can allocate risk intelligently, the parties have to reconcile the venture stack sitting underneath the sale. For Delaware startups that often means charter rights, voting agreements, drag-along mechanics, transfer restrictions, preferred stock economics, SAFEs, options, and disclosure schedules that convert diligence findings into legally operative exceptions. [[CITE:cite_295fc761-1908-4708-9c6f-f7438e6f1e7d]][[CITE:cite_a9266ab0-76b7-4cc6-9559-f649d93bc3e7]][[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]][[CITE:cite_35580cae-b796-4761-bf2f-7ca95686c1c5]][[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]][[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]]",
-  "firm_differences": "The real differences are differences of emphasis, not doctrinal conflict. Venable and the Delaware statutory materials do structure work: they explain why stock purchases, mergers, and asset sales produce different approval mechanics and different consequences for post-closing obligations. Cooley focuses on shareholder coordination and schedules, which is where many startup deals become operationally difficult. Pillsbury pushes hardest on code ownership, contractor papering, and open-source hygiene. Davis Polk adds a newer warning that AI and data issues now need explicit transaction drafting rather than being left to generic IP language. SRS Acquiom is least startup-specific, but most useful for current market architecture on earnouts, escrow, and indemnity customization. [[CITE:cite_2377d441-3b0d-471e-ab87-68745a871dc2]][[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]][[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]][[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]][[CITE:cite_2a018b66-6589-45d7-845d-b091d8b11884]][[CITE:cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48]]\n\nThat split matters for scope. A durable note should not try to become a full startup-exit treatise covering every tax, securities, compensation, and employment issue that may arise in a sale. The more maintainable path is a Delaware drafting note that stays close to the agreement itself and flags narrower overlays, such as QSBS, 280G, or securities-law questions, only when the specific deal requires them. [[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]][[CITE:cite_2377d441-3b0d-471e-ab87-68745a871dc2]]",
+  "executive_summary": "This note is about drafting a stock purchase agreement for the acquisition of a Delaware-incorporated venture-backed startup. It is not a general private-M&A survey and it is not a merger-agreement note. The maintainable core is narrower: start with orthodox SPA architecture,[[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]] then tailor it around the startup document stack that actually governs the target, including charter rights, investor agreements, transfer restrictions,[[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]] SAFEs[[CITE:cite_35580cae-b796-4761-bf2f-7ca95686c1c5]] or notes, employee equity, and software-driven product risk.\n\nGeneric private-company precedent usually breaks first on structure, capitalization math, and rep-and-schedule design. Delaware law makes clear that stock transfers,[[CITE:cite_295fc761-1908-4708-9c6f-f7438e6f1e7d]] mergers,[[CITE:cite_5da1edaf-1356-4497-bba9-e3db327a5545]] and asset sales[[CITE:cite_5747d905-71c4-4b66-b6b2-41d4cc55029d]] do not operate the same way, and startup sources show why venture-backed targets add a second layer of drafting complexity on top of that baseline. A useful startup SPA note should therefore stay focused on the drafting issues that repeatedly change the agreement itself: structure, approvals,[[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]] cap table treatment, startup-specific reps and schedules,[[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]] and post-closing risk allocation.",
+  "firm_consensus": "The strongest public practitioner sources converge on a simple point: a startup SPA should not be drafted as if it were merely a shorter version of a generic private-company purchase agreement. The ABA's new Model Short SPA is explicit that even a modern public drafting aid is only a starting point for experienced counsel and must be tailored to the target, industry, and transaction.[[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]] Cooley,[[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]][[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]] Pillsbury,[[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]] and Davis Polk[[CITE:cite_2a018b66-6589-45d7-845d-b091d8b11884]] each identify startup-specific drafting pressure points that standard forms routinely miss, while SRS Acquiom's current deal-terms work reinforces that indemnity, escrow, earnout, and insurance architecture still turn on transaction-specific design rather than folklore about what is supposedly \"market.\"[[CITE:cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48]]\n\nThe same sources also support a more startup-specific consensus: before the SPA can allocate risk intelligently, the parties have to reconcile the venture stack sitting underneath the sale. For Delaware startups that often means charter rights,[[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]] voting agreements,[[CITE:cite_a9266ab0-76b7-4cc6-9559-f649d93bc3e7]] drag-along mechanics,[[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]] transfer restrictions,[[CITE:cite_295fc761-1908-4708-9c6f-f7438e6f1e7d]] preferred stock economics, SAFEs, options,[[CITE:cite_35580cae-b796-4761-bf2f-7ca95686c1c5]] and disclosure schedules that convert diligence findings into legally operative exceptions.[[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]]",
+  "firm_differences": "The real differences are differences of emphasis, not doctrinal conflict. Venable and the Delaware statutory materials do structure work: they explain why stock purchases, mergers, and asset sales produce different approval mechanics and different consequences for post-closing obligations.[[CITE:cite_2377d441-3b0d-471e-ab87-68745a871dc2]] Cooley focuses on shareholder coordination[[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]] and schedules,[[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]] which is where many startup deals become operationally difficult. Pillsbury pushes hardest on code ownership, contractor papering, and open-source hygiene.[[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]] Davis Polk adds a newer warning that AI and data issues now need explicit transaction drafting rather than being left to generic IP language.[[CITE:cite_2a018b66-6589-45d7-845d-b091d8b11884]] SRS Acquiom is least startup-specific, but most useful for current market architecture on earnouts, escrow, and indemnity customization.[[CITE:cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48]]\n\nThat split matters for scope. A durable note should not try to become a full startup-exit treatise covering every tax, securities, compensation, and employment issue that may arise in a sale. The more maintainable path is a Delaware drafting note that stays close to the agreement itself[[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]] and flags narrower overlays, such as QSBS, 280G, or securities-law questions, only when the specific deal requires them.[[CITE:cite_2377d441-3b0d-471e-ab87-68745a871dc2]]",
   "recent_developments": [
     {
       "date": "2026-04",
-      "event": "ABA Business Law Today announced the Model Short Stock Purchase Agreement (U.S. Version) as a new public drafting aid for private stock purchases and emphasized that it is only a starting point for experienced counsel, not a safe form to use without deal-specific tailoring. [[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]]"
+      "event": "ABA Business Law Today announced the Model Short Stock Purchase Agreement (U.S. Version) as a new public drafting aid for private stock purchases and emphasized that it is only a starting point for experienced counsel, not a safe form to use without deal-specific tailoring.[[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]]"
     },
     {
       "date": "2026-04",
-      "event": "SRS Acquiom previewed its 2026 M&A Deal Terms Study and highlighted rising earnout usage plus diligence-driven customization of indemnification protections across more than 2,300 private-target acquisitions. [[CITE:cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48]]"
+      "event": "SRS Acquiom previewed its 2026 M&A Deal Terms Study and highlighted rising earnout usage plus diligence-driven customization of indemnification protections across more than 2,300 private-target acquisitions.[[CITE:cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48]]"
     },
     {
       "date": "2025-10-01",
-      "event": "Pillsbury published updated startup IP guidance warning that unclear code ownership and weak OSS hygiene can derail financing or acquisitions. [[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]]"
+      "event": "Pillsbury published updated startup IP guidance warning that unclear code ownership and weak OSS hygiene can derail financing or acquisitions.[[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]]"
     }
   ],
   "questions": [
     {
       "id": "qa_245ba969-d92a-48a1-86fe-7c23a65ed9b7",
       "question": "What makes a startup stock purchase agreement different from a generic private-company SPA?",
-      "answer": "A startup SPA is still a stock purchase agreement, so the baseline private-M&A architecture remains recognizable. But Delaware law does not let counsel flatten structure. Stock transfers are governed by DGCL sections 201 and 202, which tie the sale to Article 8 mechanics and to enforceable transfer restrictions. Mergers and asset sales instead run through different statutory paths, including sections 251, 259, and 271, which change approval mechanics and what happens to assets and liabilities. In other words, \"stock sale\" is not just a label; it changes how the deal works. [[CITE:cite_295fc761-1908-4708-9c6f-f7438e6f1e7d]][[CITE:cite_5da1edaf-1356-4497-bba9-e3db327a5545]][[CITE:cite_5747d905-71c4-4b66-b6b2-41d4cc55029d]]\n\nThe startup-specific difference is what sits underneath that form. Venture-backed startups often carry multiple preferred series, investor-vote mechanics, drag-along provisions, SAFEs, options, and product-centric diligence issues that a generic lower-middle-market precedent may not operationalize cleanly. That is why the better drafting move is not to abandon standard SPA structure, but to use it as a framework and then tailor definitions, conditions, schedules, and closing mechanics to the target's actual capitalization and product risk. [[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]][[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]][[CITE:cite_35580cae-b796-4761-bf2f-7ca95686c1c5]][[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]]"
+      "answer": "A startup SPA is still a stock purchase agreement, so the baseline private-M&A architecture remains recognizable. But Delaware law does not let counsel flatten structure. Stock transfers are governed by DGCL sections 201 and 202, which tie the sale to Article 8 mechanics and to enforceable transfer restrictions.[[CITE:cite_295fc761-1908-4708-9c6f-f7438e6f1e7d]] Mergers and asset sales instead run through different statutory paths, including sections 251, 259,[[CITE:cite_5da1edaf-1356-4497-bba9-e3db327a5545]] and 271,[[CITE:cite_5747d905-71c4-4b66-b6b2-41d4cc55029d]] which change approval mechanics and what happens to assets and liabilities. In other words, \"stock sale\" is not just a label; it changes how the deal works.\n\nThe startup-specific difference is what sits underneath that form. Venture-backed startups often carry multiple preferred series,[[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]] investor-vote mechanics, drag-along provisions,[[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]] SAFEs,[[CITE:cite_35580cae-b796-4761-bf2f-7ca95686c1c5]] options, and product-centric diligence issues that a generic lower-middle-market precedent may not operationalize cleanly. That is why the better drafting move is not to abandon standard SPA structure,[[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]] but to use it as a framework and then tailor definitions, conditions, schedules, and closing mechanics to the target's actual capitalization and product risk."
     },
     {
       "id": "qa_112565c9-4d5d-4aec-8fbd-a818c5fd0e84",
       "question": "What approvals and venture-document constraints should be cleared before the SPA is treated as executable?",
-      "answer": "For a Delaware startup, the approval stack usually begins before the SPA itself. Counsel needs to identify which board approvals, stockholder approvals, class or series votes, charter rights, voting-agreement obligations, drag-along mechanics, ROFR or co-sale limits, and notice requirements must be satisfied so that the signing path matches both Delaware law and the existing venture documents. DGCL section 228 is important because it permits stockholder action by written consent if the requisite votes are obtained and delivered correctly, while section 202 matters because transfer restrictions are enforceable only if the deal team accounts for how they bind the holders and securities involved. [[CITE:cite_295fc761-1908-4708-9c6f-f7438e6f1e7d]][[CITE:cite_a9266ab0-76b7-4cc6-9559-f649d93bc3e7]][[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]]\n\nCooley's drag-along guidance is useful because it explains the practical reason these provisions dominate startup sale mechanics: they are designed to force coordinated support for a company sale once the stated conditions are met. That means the startup SPA should be drafted only after counsel has mapped which holders can actually be dragged, which signatures are still needed, and which closing conditions should remain tied to affirmative consents rather than assumed cooperation. [[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]][[CITE:cite_2377d441-3b0d-471e-ab87-68745a871dc2]]"
+      "answer": "For a Delaware startup, the approval stack usually begins before the SPA itself. Counsel needs to identify which board approvals, stockholder approvals, class or series votes, charter rights,[[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]] voting-agreement obligations, drag-along mechanics, ROFR or co-sale limits, and notice requirements must be satisfied so that the signing path matches both Delaware law and the existing venture documents. DGCL section 228 is important because it permits stockholder action by written consent if the requisite votes are obtained and delivered correctly,[[CITE:cite_a9266ab0-76b7-4cc6-9559-f649d93bc3e7]] while section 202 matters because transfer restrictions are enforceable only if the deal team accounts for how they bind the holders and securities involved.[[CITE:cite_295fc761-1908-4708-9c6f-f7438e6f1e7d]]\n\nCooley's drag-along guidance is useful because it explains the practical reason these provisions dominate startup sale mechanics: they are designed to force coordinated support for a company sale once the stated conditions are met.[[CITE:cite_276ef753-8bf0-44df-8da4-778d703c31fa]] That means the startup SPA should be drafted only after counsel has mapped which holders can actually be dragged, which signatures are still needed, and which closing conditions should remain tied to affirmative consents rather than assumed cooperation.[[CITE:cite_2377d441-3b0d-471e-ab87-68745a871dc2]]"
     },
     {
       "id": "qa_ea94037a-32f8-4695-9895-047b1eb5011b",
       "question": "How should capitalization and purchase-price mechanics be drafted for a venture-backed target?",
-      "answer": "The purchase-price section has to reflect the target's real cap table, not the company's preferred story about the cap table. For a venture-backed startup that usually means working from a consideration spreadsheet that captures common and preferred stock, options and other awards, warrants, SAFEs, convertible notes, transaction bonuses, debt, and transaction expenses. The drafting objective is not just descriptive accuracy. It is to make sure the agreement tells the paying agent, representative, and counsel exactly how consideration moves through the capitalization stack. [[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]][[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]][[CITE:cite_7e729751-b0e8-44cf-a0bb-e4fc35763b94]]\n\nYC's SAFE materials are especially helpful here because they explain why startup acquisition math cannot stop at outstanding shares. YC designed the post-money SAFE so founders and investors can calculate ownership precisely, and its documents and user guide treat conversion and liquidity-event mechanics as part of the instrument itself. That means a startup SPA should expressly state how each SAFE or similar instrument is being cashed out, converted, canceled, or otherwise handled at closing instead of leaving the answer to an informal funds-flow memo. [[CITE:cite_35580cae-b796-4761-bf2f-7ca95686c1c5]]"
+      "answer": "The purchase-price section has to reflect the target's real cap table, not the company's preferred story about the cap table. For a venture-backed startup that usually means working from a consideration spreadsheet that captures common and preferred stock, options and other awards, warrants, SAFEs, convertible notes, transaction bonuses, debt, and transaction expenses.[[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]][[CITE:cite_7e729751-b0e8-44cf-a0bb-e4fc35763b94]] The drafting objective is not just descriptive accuracy. It is to make sure the agreement tells the paying agent, representative, and counsel exactly how consideration moves through the capitalization stack.[[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]]\n\nYC's SAFE materials[[CITE:cite_35580cae-b796-4761-bf2f-7ca95686c1c5]] are especially helpful here because they explain why startup acquisition math cannot stop at outstanding shares. YC designed the post-money SAFE so founders and investors can calculate ownership precisely, and its documents and user guide treat conversion and liquidity-event mechanics as part of the instrument itself. That means a startup SPA should expressly state how each SAFE or similar instrument is being cashed out, converted, canceled, or otherwise handled at closing instead of leaving the answer to an informal funds-flow memo."
     },
     {
       "id": "qa_728efc29-4540-4f79-8560-bb5b7e20d633",
       "question": "Where do generic reps and schedules usually fail in a startup stock deal?",
-      "answer": "The failure point is usually not the existence of the rep section. It is the mismatch between generic rep categories and startup-specific facts. Startup deals routinely need sharper work on capitalization accuracy, transfer restrictions, equity-plan history, founder and contractor IP assignments, OSS usage, key product or data rights, and schedule architecture for customer or vendor concentration. Cooley's disclosure-schedule guidance is useful because it frames the schedules as the answer set to the representations' questions. In a startup transaction, that Q&A logic should be applied deliberately rather than treated as a clerical exercise at the end of diligence. [[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]][[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]]\n\nThe practical consequence is that startup-specific reps should usually be paired with startup-specific data pulls. If the target depends on SAFEs, the schedules need instrument-level treatment. If it depends on OSS or contractor-developed code, the schedules need code-ownership and license disclosures. If it depends on AI or data licensing, the schedules should not hide those issues inside a generic IP basket. The schedule set is where diligence becomes executable drafting. [[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]][[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]][[CITE:cite_2a018b66-6589-45d7-845d-b091d8b11884]]"
+      "answer": "The failure point is usually not the existence of the rep section. It is the mismatch between generic rep categories and startup-specific facts. Startup deals routinely need sharper work on capitalization accuracy, transfer restrictions, equity-plan history, founder and contractor IP assignments, OSS usage, key product or data rights, and schedule architecture for customer or vendor concentration.[[CITE:cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b]] Cooley's disclosure-schedule guidance is useful because it frames the schedules as the answer set to the representations' questions.[[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]] In a startup transaction, that Q&A logic should be applied deliberately rather than treated as a clerical exercise at the end of diligence.\n\nThe practical consequence is that startup-specific reps should usually be paired with startup-specific data pulls. If the target depends on SAFEs, the schedules need instrument-level treatment. If it depends on OSS or contractor-developed code, the schedules need code-ownership and license disclosures.[[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]] If it depends on AI or data licensing, the schedules should not hide those issues inside a generic IP basket.[[CITE:cite_2a018b66-6589-45d7-845d-b091d8b11884]] The schedule set is where diligence becomes executable drafting.[[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]]"
     },
     {
       "id": "qa_0f7d97ff-b984-4aa7-9e09-12eaaafcc5c8",
       "question": "How should IP chain of title and open-source issues be handled?",
-      "answer": "Startup buyers often care less about the abstract existence of IP reps than about whether the company actually owns what it thinks it owns. The federal backbone is straightforward. Copyright transfers are generally not valid unless they are in writing and signed by the rights holder, and patent interests are assignable by written instrument. Pillsbury's startup IP guidance translates that rule into startup practice: paying a developer is not enough if the company never obtained a written assignment, and weak OSS hygiene can surface as an acquisition problem rather than as a mere engineering preference. [[CITE:cite_eed385cd-4bf0-4c56-bdec-20564b11275c]][[CITE:cite_c54253ca-5683-4ddd-b983-98b82e770b54]][[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]]\n\nDrafting should therefore separate three questions that generic forms often collapse together: whether the company has documented ownership of code and other core IP, whether any exceptions belong on a schedule, and whether identified gaps need a closing deliverable, special indemnity, or purchase-price adjustment. Open-source use should likewise be treated as a specific diligence-and-schedule problem, not buried in a conclusory statement that the company \"owns or has rights to use\" its IP. [[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]][[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]]"
+      "answer": "Startup buyers often care less about the abstract existence of IP reps than about whether the company actually owns what it thinks it owns. The federal backbone is straightforward. Copyright transfers are generally not valid unless they are in writing and signed by the rights holder,[[CITE:cite_eed385cd-4bf0-4c56-bdec-20564b11275c]] and patent interests are assignable by written instrument.[[CITE:cite_c54253ca-5683-4ddd-b983-98b82e770b54]] Pillsbury's startup IP guidance translates that rule into startup practice: paying a developer is not enough if the company never obtained a written assignment, and weak OSS hygiene can surface as an acquisition problem rather than as a mere engineering preference.[[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]]\n\nDrafting should therefore separate three questions that generic forms often collapse together: whether the company has documented ownership of code and other core IP,[[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]] whether any exceptions belong on a schedule, and whether identified gaps need a closing deliverable, special indemnity, or purchase-price adjustment.[[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]] Open-source use should likewise be treated as a specific diligence-and-schedule problem, not buried in a conclusory statement that the company \"owns or has rights to use\" its IP."
     },
     {
       "id": "qa_79ddf8ed-c111-495d-a630-02e4756b52b3",
       "question": "How should AI, data, and product-compliance issues show up in the SPA?",
-      "answer": "Davis Polk's generative-AI transaction guidance makes the modern point clearly: for AI-enabled targets, transaction documents now need to ask narrower questions about training data rights, third-party model dependencies, output ownership, product-change controls, and compliance risk. A startup SPA should not automatically add a long AI appendix to every software deal, but it should also not pretend that a generic IP rep fully captures an AI product's legal risk surface. [[CITE:cite_2a018b66-6589-45d7-845d-b091d8b11884]]\n\nThe maintainable drafting rule is to make the rep package track the actual product. If the startup's value is tied to training data, model tuning, or licensed datasets, counsel should say so directly in reps, covenants, or schedules. If the startup is not meaningfully AI-dependent, counsel should resist ornamental AI language and focus instead on the more durable startup issues: IP ownership, OSS, customer-facing product obligations, and incident history. [[CITE:cite_2a018b66-6589-45d7-845d-b091d8b11884]][[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]]"
+      "answer": "Davis Polk's generative-AI transaction guidance[[CITE:cite_2a018b66-6589-45d7-845d-b091d8b11884]] makes the modern point clearly: for AI-enabled targets, transaction documents now need to ask narrower questions about training data rights, third-party model dependencies, output ownership, product-change controls, and compliance risk. A startup SPA should not automatically add a long AI appendix to every software deal, but it should also not pretend that a generic IP rep fully captures an AI product's legal risk surface.\n\nThe maintainable drafting rule is to make the rep package track the actual product. If the startup's value is tied to training data, model tuning, or licensed datasets, counsel should say so directly in reps, covenants, or schedules.[[CITE:cite_2a018b66-6589-45d7-845d-b091d8b11884]] If the startup is not meaningfully AI-dependent, counsel should resist ornamental AI language and focus instead on the more durable startup issues: IP ownership, OSS, customer-facing product obligations, and incident history.[[CITE:cite_c011e229-cbb6-4698-929e-5c72fec72587]]"
     },
     {
       "id": "qa_941972be-554c-4431-9b95-ddbe1dd674d0",
       "question": "What should disclosure schedules and closing deliverables actually do in a startup stock deal?",
-      "answer": "Disclosure schedules should convert diligence into legally operative exceptions, not operate as a late-stage data dump. Cooley's explanation is useful because it shows why schedules matter in both investments and acquisitions: the agreement asks the questions, and the schedules supply the answer set that makes the representations true. In a startup sale, that usually means the schedule package should be designed around the issues most likely to break the deal later, including capitalization, SAFEs and notes, option and warrant treatment, IP assignments, OSS, data or AI exceptions, key contracts, and required consents. [[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]][[CITE:cite_35580cae-b796-4761-bf2f-7ca95686c1c5]][[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]]\n\nClosing deliverables should prove that the cleanup actually happened. Depending on the deal, that can include board and stockholder consents, drag-along documentation, payoff or termination letters, SAFE or note payoff documents, equity-award notices, updated capitalization schedules, assignment confirmations, or representative and escrow documents. The drafting goal is not to collect paper for its own sake. It is to keep known startup frictions out of post-closing fights about consideration, ownership, or who was bound to what. [[CITE:cite_a9266ab0-76b7-4cc6-9559-f649d93bc3e7]][[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]][[CITE:cite_2377d441-3b0d-471e-ab87-68745a871dc2]]"
+      "answer": "Disclosure schedules should convert diligence into legally operative exceptions, not operate as a late-stage data dump. Cooley's explanation is useful because it shows why schedules matter in both investments and acquisitions: the agreement asks the questions, and the schedules supply the answer set that makes the representations true.[[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]] In a startup sale, that usually means the schedule package should be designed around the issues most likely to break the deal later, including capitalization,[[CITE:cite_f288cd43-7b0b-4eea-9695-01ebf5739835]] SAFEs[[CITE:cite_35580cae-b796-4761-bf2f-7ca95686c1c5]] and notes, option and warrant treatment, IP assignments, OSS, data or AI exceptions, key contracts, and required consents.\n\nClosing deliverables should prove that the cleanup actually happened. Depending on the deal, that can include board and stockholder consents,[[CITE:cite_a9266ab0-76b7-4cc6-9559-f649d93bc3e7]] drag-along documentation, payoff or termination letters, SAFE or note payoff documents, equity-award notices, updated capitalization schedules,[[CITE:cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f]] assignment confirmations, or representative and escrow documents. The drafting goal is not to collect paper for its own sake. It is to keep known startup frictions out of post-closing fights about consideration, ownership, or who was bound to what.[[CITE:cite_2377d441-3b0d-471e-ab87-68745a871dc2]]"
     },
     {
       "id": "qa_1c8848e1-8604-4455-a853-1e9291d5e7c6",
       "question": "How should indemnity, escrow, earnouts, and insurance be approached in a startup SPA?",
-      "answer": "Risk allocation should be drafted from current data and identified risks, not from generic memory of the last private-company form. SRS Acquiom's 2026 study preview highlights two themes that matter here: earnouts remain important in private-target M&A, and indemnification protections are increasingly customized based on diligence findings rather than copied wholesale. That fits startup practice. Venture-backed targets often have a few concentrated risks that matter far more than the rest of the rep package, such as cap-table defects, IP ownership gaps, or product and data issues. [[CITE:cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48]]\n\nFor the same reason, counsel should draft seller exposure intentionally. If a merger structure is used, Venable's Cigna discussion is a reminder that post-closing obligations should not be smuggled in later through a letter of transmittal or left open-ended for non-signing holders. In a stock purchase, that concern often pushes the team toward cleaner signature planning, express escrow mechanics, and specific treatment of any contingent payments. If earnouts are used, the metric definitions and operating covenants need just as much care as the indemnity basket and cap. [[CITE:cite_2377d441-3b0d-471e-ab87-68745a871dc2]][[CITE:cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48]]"
+      "answer": "Risk allocation should be drafted from current data and identified risks, not from generic memory of the last private-company form. SRS Acquiom's 2026 study preview[[CITE:cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48]] highlights two themes that matter here: earnouts remain important in private-target M&A, and indemnification protections are increasingly customized based on diligence findings rather than copied wholesale. That fits startup practice. Venture-backed targets often have a few concentrated risks that matter far more than the rest of the rep package, such as cap-table defects, IP ownership gaps, or product and data issues.\n\nFor the same reason, counsel should draft seller exposure intentionally. If a merger structure is used, Venable's Cigna discussion[[CITE:cite_2377d441-3b0d-471e-ab87-68745a871dc2]] is a reminder that post-closing obligations should not be smuggled in later through a letter of transmittal or left open-ended for non-signing holders. In a stock purchase, that concern often pushes the team toward cleaner signature planning, express escrow mechanics, and specific treatment of any contingent payments. If earnouts are used, the metric definitions and operating covenants need just as much care as the indemnity basket and cap.[[CITE:cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48]]"
     }
   ],
   "references": [
@@ -316,6 +316,184 @@
       "source_type": "statute",
       "title": "35 U.S.C. § 261",
       "date": "current"
+    }
+  },
+  "_sources": {
+    "cite_5da1edaf-1356-4497-bba9-e3db327a5545": {
+      "source_ref": "cite_5da1edaf-1356-4497-bba9-e3db327a5545",
+      "url": "https://delcode.delaware.gov/title8/c001/sc09/index.html",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
+    },
+    "cite_c011e229-cbb6-4698-929e-5c72fec72587": {
+      "source_ref": "cite_c011e229-cbb6-4698-929e-5c72fec72587",
+      "url": "https://www.pillsburypropel.com/guidance/startup-ip-myths-that-can-cost-you-millions-or-kill-your-exit",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": false,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_2377d441-3b0d-471e-ab87-68745a871dc2": {
+      "source_ref": "cite_2377d441-3b0d-471e-ab87-68745a871dc2",
+      "url": "https://www.venable.com/insights/publications/2021/07/structuring-a-private-company-acquisition-as-a",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_7e729751-b0e8-44cf-a0bb-e4fc35763b94": {
+      "source_ref": "cite_7e729751-b0e8-44cf-a0bb-e4fc35763b94",
+      "url": "https://nvca.org/document/nvca-model-document-stock-purchase-agreement-2/",
+      "source_type": "trade_association",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": false,
+        "topic_match": true,
+        "source_class": "official_guidance"
+      }
+    },
+    "cite_276ef753-8bf0-44df-8da4-778d703c31fa": {
+      "source_ref": "cite_276ef753-8bf0-44df-8da4-778d703c31fa",
+      "url": "https://www.cooleygo.com/what-is-a-drag-along/",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f": {
+      "source_ref": "cite_3d8bfe3e-1e6f-4c9a-b243-97f4058b1a0f",
+      "url": "https://www.cooleygo.com/what-is-a-disclosure-schedule-and-why-do-i-need-to-prepare-one/",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": false,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_35580cae-b796-4761-bf2f-7ca95686c1c5": {
+      "source_ref": "cite_35580cae-b796-4761-bf2f-7ca95686c1c5",
+      "url": "https://www.ycombinator.com/documents",
+      "source_type": "other",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": false,
+        "topic_match": true,
+        "source_class": "official_guidance"
+      }
+    },
+    "cite_5747d905-71c4-4b66-b6b2-41d4cc55029d": {
+      "source_ref": "cite_5747d905-71c4-4b66-b6b2-41d4cc55029d",
+      "url": "https://delcode.delaware.gov/title8/c001/sc10/index.html",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
+    },
+    "cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48": {
+      "source_ref": "cite_9c4d12f0-d2c9-46b8-bf57-59e2d6971f48",
+      "url": "https://www.srsacquiom.com/our-insights/deal-terms-study/",
+      "source_type": "other",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": false,
+        "topic_match": true,
+        "source_class": "official_guidance"
+      }
+    },
+    "cite_eed385cd-4bf0-4c56-bdec-20564b11275c": {
+      "source_ref": "cite_eed385cd-4bf0-4c56-bdec-20564b11275c",
+      "url": "https://www.law.cornell.edu/uscode/text/17/204",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
+    },
+    "cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b": {
+      "source_ref": "cite_0993a1c0-c6a4-4ee2-9b32-67745c986e6b",
+      "url": "https://businesslawtoday.org/2026/04/announcing-model-short-stock-purchase-agreement-us-version/",
+      "source_type": "scholarship",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": false,
+        "topic_match": true,
+        "source_class": "official_guidance"
+      }
+    },
+    "cite_2a018b66-6589-45d7-845d-b091d8b11884": {
+      "source_ref": "cite_2a018b66-6589-45d7-845d-b091d8b11884",
+      "url": "https://www.davispolk.com/insights/client-update/navigating-generative-ai-m-transactions",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": false,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_295fc761-1908-4708-9c6f-f7438e6f1e7d": {
+      "source_ref": "cite_295fc761-1908-4708-9c6f-f7438e6f1e7d",
+      "url": "https://delcode.delaware.gov/title8/c001/sc06/index.html",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
+    },
+    "cite_a9266ab0-76b7-4cc6-9559-f649d93bc3e7": {
+      "source_ref": "cite_a9266ab0-76b7-4cc6-9559-f649d93bc3e7",
+      "url": "https://delcode.delaware.gov/title8/c001/sc07/index.html",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
+    },
+    "cite_c54253ca-5683-4ddd-b983-98b82e770b54": {
+      "source_ref": "cite_c54253ca-5683-4ddd-b983-98b82e770b54",
+      "url": "https://www.law.cornell.edu/uscode/text/35/261",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
+    },
+    "cite_f288cd43-7b0b-4eea-9695-01ebf5739835": {
+      "source_ref": "cite_f288cd43-7b0b-4eea-9695-01ebf5739835",
+      "url": "https://nvca.org/model-legal-documents/",
+      "source_type": "trade_association",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": false,
+        "topic_match": true,
+        "source_class": "official_guidance"
+      }
     }
   },
   "_metadata": {


### PR DESCRIPTION
## Summary

Refreshes three practice-note JSON exports to pick up per-claim citation marker positions merged in `UseJunior/legal-context` PR #89 (merge commit `32a97e75fef2f1e3b05826d1931d88516c71fa3f`).

- `non-compete-wyoming.json` — 68 markers / 10 citations / 6 firms
- `bonus-compensation-new-york.json` — 59 markers / 16 citations / 3 firms
- `startup-sale-delaware-startup-stock-purchase-agreement.json` — 69 markers / 16 citations / 4 firms

Total: 196 markers redistributed from paragraph-end clusters to mid-sentence positions that follow the specific claim each source supports.

Also carried forward from PR #89's follow-up commit `d50be3e` ("tighten per-claim marker attribution per Codex peer review"): minor prose tightening in Wyoming (2 edits — extra "and" dropped; physician-subsection sentence restructured) and NY (3 edits — paragraph break adjusted; sentence restructure; case-list tightened). Delaware has marker-only changes. These prose edits are intentional and were peer-reviewed upstream.

This refresh also newly projects the `_sources` block (10/16/16 entries) into all three files — previously absent on the exports target.

**Verified pre-copy (jq structural gate):**
- `_metadata` byte-identical between source and target
- `citations` key set unchanged (WY=10, NY=16, DE=16)
- `references` set (sorted by id) unchanged
- `firm_count` unchanged (6, 3, 4)
- `_sources` newly added

**Source lineage:** `UseJunior/legal-context@32a97e75fef2f1e3b05826d1931d88516c71fa3f`

Once this merges, `usejunior.com/legal/{non-compete/wyoming,bonus-compensation/new-york,startup-sale/delaware-startup-stock-purchase-agreement}/` render the redistributed `[N]` superscripts on the next Vercel deploy (~5 min). `dev-website/src/_data/wiki.js` uses raw-URL fetch at `legal-context-exports/main/practice-notes/` (not pinned to a SHA), so no companion dev-website PR is required.

## Test plan

- [ ] `jq '.citations | keys | length'` returns 10 / 16 / 16 across the three files.
- [ ] `jq 'has("_sources")'` returns `true` for all three.
- [ ] `jq '._metadata.firm_count'` returns 6 / 3 / 4.
- [ ] Vercel preview HTML shows Wyoming Executive Summary marker after "retroactively voided," (mid-sentence), not at sentence end — `curl -sL <preview>/legal/non-compete/wyoming/ | grep -oE 'retroactively voided[^<]*<sup' | head -1`.
- [ ] After merge: prod `curl -sL https://usejunior.com/legal/non-compete/wyoming/ | grep -oE 'retroactively voided[^<]*<sup'` shows the repositioned superscript within ~10 min of Vercel deploy.

## Rollback

If the refresh is wrong after merge, revert the squash commit in `legal-context-exports`; Vercel will redeploy the previous state within ~5 min. No downstream coordination needed.