### PR TITLE
ci: trigger dev-website Vercel deploy on push to main

### DIFF
--- a/.github/workflows/trigger-dev-website-deploy.yml
+++ b/.github/workflows/trigger-dev-website-deploy.yml
@@ -1,0 +1,36 @@
+name: Trigger Dev Website Deploy
+
+on:
+  # Note on paths: dev-website's src/_data/wiki.js fetches practice-note JSON
+  # and src/lib/template-html-loader.js fetches template HTML. wiki-html/ has
+  # no consumer in dev-website's production build, so it is intentionally
+  # excluded.
+  push:
+    branches: [main]
+    paths:
+      - 'practice-notes/**'
+      - 'template-html/**'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: trigger-dev-website-deploy
+  cancel-in-progress: true
+
+jobs:
+  trigger:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    steps:
+      - name: POST Vercel deploy hook
+        env:
+          VERCEL_DEPLOY_HOOK: ${{ secrets.DEV_WEBSITE_VERCEL_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$VERCEL_DEPLOY_HOOK" ]; then
+            echo "::error::DEV_WEBSITE_VERCEL_DEPLOY_HOOK secret is not set."
+            exit 1
+          fi
+          curl --fail-with-body --silent --show-error \
+            --retry 3 --retry-delay 5 --max-time 30 \
+            -X POST "$VERCEL_DEPLOY_HOOK"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/trigger-dev-website-deploy.yml` that POSTs the dev-website Vercel deploy hook on push to `main` filtered by `practice-notes/**` + `template-html/**`.
- Closes the manual `vercel redeploy` step that surfaced during PR #2 (35+ minutes of stale prod after the per-claim citation refresh landed).
- Closes #3.

## Why these paths
`dev-website/src/_data/wiki.js` fetches practice-note JSON from `practice-notes/`; `src/lib/template-html-loader.js` fetches per-slug template HTML from `template-html/`. `wiki-html/` has no consumer in dev-website's production build, so it is intentionally excluded from the trigger to avoid unnecessary deploys.

## Hardening (vs. the issue sketch)
- `workflow_dispatch:` for bootstrap and manual retry — needed because this PR itself only touches `.github/workflows/*` and so does not match `push.paths`.
- `permissions: {}` at workflow level (empty `GITHUB_TOKEN`).
- `runs-on: ubuntu-24.04` (pinned) + `timeout-minutes: 1`.
- `curl --fail-with-body --silent --show-error --retry 3 --retry-delay 5 --max-time 30`.
- `concurrency` with `cancel-in-progress: true` (queue/noise control; Vercel debounces deploy-hook POSTs on its side).
- Missing-secret guard surfaces as a `::error::` annotation rather than silently POSTing an empty URL.

## Test plan
- [ ] After merge, run `Trigger Dev Website Deploy` via `workflow_dispatch` on `main`; confirm a new Vercel deployment appears within ~30s.
- [ ] Touch `practice-notes/<some-slug>.json` on `main`; confirm the workflow runs from the `push` event and a deployment appears.
- [ ] Verify prod (`usejunior.com`) reflects the new artifact (not just a cache hit).
- [ ] Negative test: edit `README.md` only on `main` and confirm the workflow does NOT run.

## Setup already complete (outside this PR)
- Vercel deploy hook `legal-context-exports-main` created on the `dev-website` project (branch `main`).
- `DEV_WEBSITE_VERCEL_DEPLOY_HOOK` secret set on this repo via `gh secret set`.