### PR TITLE
refresh: Wyoming non-compete export with corrected duration_basis

### DIFF
--- a/practice-notes/non-compete-wyoming.json
+++ b/practice-notes/non-compete-wyoming.json
@@ -1,5 +1,5 @@
 {
-  "executive_summary": "Wyoming now has a two-track non-compete regime. For contracts entered into on or after July 1, 2025, Senate File 107, codified at W.S. 1-23-108, voids any covenant not to compete that restricts the right of any person to receive compensation for skilled or unskilled labor, subject only to four listed exceptions: sale-of-business covenants, trade-secret protection, capped expense-recovery provisions, and covenants for executive and management personnel and their professional staff.[[FN:fn_0ea39a42-4048-4e88-8254-486dd676e9c2]] The same enactment separately voids physician non-compete provisions and protects disclosure of new contact information to patients with rare disorders.[[FN:fn_9b660fcb-f524-410f-abee-4da569360758]][[FN:fn_a694bc9e-ac01-410a-a949-bd719b67a42e]]\n\nPre-July 1, 2025 agreements were not retroactively voided,[[FN:fn_5ddda782-eb6c-4513-adbd-59024c670391]] but they were not made easy to enforce either. Wyoming common law already treated non-competes as presumptively invalid restraints on trade, placed the burden on the employer to justify them, and required reasonable consideration,[[FN:fn_c8ef8627-3906-4c43-bf9b-f99bb613ba98]] and after *Hassler* forbade courts from blue-penciling unreasonable covenants to save them.[[FN:fn_8678734b-d575-424b-b784-7429d8955aa0]] *Brown* also confirms that continued employment alone is not sufficient consideration when an existing employee is asked to sign later.[[FN:fn_2e94d703-c687-486b-9922-2d6e16ded318]]\n\nThe remaining Wyoming questions are interpretive, not structural. State-specific firm analyses broadly read the statute's \"any person\" language to reach independent contractors as well as employees,[[FN:fn_d1f30c94-09c3-45ff-97eb-29b51e6a1b06]][[FN:fn_a6ddf973-d016-43b2-a15f-060d2f2faf5e]] but they also emphasize that Wyoming courts still have not defined the executive-and-management personnel category or resolved whether customer nonsolicits, employee nonsolicits, broad confidentiality clauses, or similar restraints will be treated as prohibited covenants not to compete.[[FN:fn_aae18236-5416-4857-9884-48b71303114d]][[FN:fn_3b5eb694-3b6e-4c91-9cca-e52e5693fb11]]",
+  "executive_summary": "Wyoming now has a two-track non-compete regime. For contracts entered into on or after July 1, 2025, Senate File 107, codified at W.S. 1-23-108, voids any covenant not to compete that restricts the right of any person to receive compensation for skilled or unskilled labor, subject only to four listed exceptions: sale-of-business covenants, trade-secret protection, capped expense-recovery provisions, and covenants for executive and management personnel and their professional staff.[[FN:fn_0ea39a42-4048-4e88-8254-486dd676e9c2]] The same enactment separately voids physician non-compete provisions and protects disclosure of new contact information to patients with rare disorders.[[FN:fn_9b660fcb-f524-410f-abee-4da569360758]][[FN:fn_a694bc9e-ac01-410a-a949-bd719b67a42e]]\n\nPre-July 1, 2025 agreements were not retroactively voided,[[FN:fn_5ddda782-eb6c-4513-adbd-59024c670391]] but they were not made easy to enforce either. Wyoming common law already treated non-competes as presumptively invalid restraints on trade, placed the burden on the employer to justify them, and required reasonable consideration,[[FN:fn_c8ef8627-3906-4c43-bf9b-f99bb613ba98]] and after *Hassler* forbade courts from blue-penciling unreasonable covenants to save them.[[FN:fn_8678734b-d575-424b-b784-7429d8955aa0]] *Brown* also confirms that continued employment alone is not sufficient consideration when an existing employee is asked to sign later.[[FN:fn_2e94d703-c687-486b-9922-2d6e16ded318]]\n\nThe remaining Wyoming questions are interpretive, not structural. State-specific firm analyses broadly read the statute's \"any person\" language to reach independent contractors as well as employees,[[FN:fn_d1f30c94-09c3-45ff-97eb-29b51e6a1b06]][[FN:fn_a6ddf973-d016-43b2-a15f-060d2f2faf5e]] but they also emphasize that Wyoming courts still have not defined the executive-and-management personnel category or resolved whether customer nonsolicits, employee nonsolicits, broad confidentiality clauses, or similar restraints will be treated as prohibited covenants not to compete.[[FN:fn_aae18236-5416-4857-9884-48b71303114d]]",
   "firm_consensus": "Ogletree,[[FN:fn_8273e801-9d09-4290-928b-40774214c595]] Littler,[[FN:fn_ddf8225d-d579-4978-b940-9e09d1bdf6f6]] Faegre,[[FN:fn_af25b725-d0d6-4aa1-a480-6f12965e6678]] Fisher Phillips,[[FN:fn_65429f95-d184-4f7c-9ebf-210a66950884]] and Holland & Hart[[FN:fn_aa4ef6a1-ffa5-4a56-bd22-82758f77f504]] all read SF 107 as a major narrowing of Wyoming practice, not a minor adjustment. They agree that the statute is prospective only, that the four statutory exceptions are the operative post-July 1, 2025 carveouts, and that physician non-competes are separately voided by subsection (b). They also agree that employers cannot assume old template language will survive a simple rollover after the effective date.\n\nThose firm analyses also sit on top of a demanding Wyoming case-law baseline. *Brown*[[FN:fn_ab96e3cd-57a8-42b5-88fc-066d3d700cbb]] and *Malave*[[FN:fn_ad14ca9f-b244-49aa-a49a-fd6a60e601a9]] describe non-competes as restraints that are strictly construed, and *Hassler*[[FN:fn_4c1650ac-de91-476b-bdf3-f73ac5356a9e]] makes drafting error much more expensive by eliminating blue-penciling. So even where a restraint arguably fits a statutory exception, Wyoming-specific commentary does not treat that as a license for careless drafting.[[FN:fn_a06ae749-e00c-4bda-b067-29e46598bf21]]",
   "firm_differences": "The sharpest source-level disagreement is over adjacent restraints. Brownstein takes the most employer-friendly view and says the statute does not affect non-solicitation, non-recruitment, or confidentiality agreements.[[FN:fn_7485922c-0295-4ac4-8ab6-5aa89adef60e]] Littler and Fisher Phillips are more cautious: Littler says the lack of an express non-solicit exception leaves the issue unclear,[[FN:fn_367d0e4c-9492-48b7-b550-1c14b9baa7a4]] and Fisher says courts still must decide whether customer nonsolicits, employee nonsolicits, broad confidentiality provisions, or anti-moonlighting clauses count as covered non-compete covenants under the new language.[[FN:fn_92939147-6bb7-4a78-b6f9-a1dbca0cda9a]] The safest Wyoming-specific synthesis is uncertainty, not a blanket rule of safety.\n\nThe firms also vary in how aggressively they use Colorado analogies for the executive-and-management exception. Fisher Phillips and Holland & Hart develop Colorado comparisons in some detail,[[FN:fn_81397040-13e1-4b40-892b-9aad4512436e]][[FN:fn_74ee62bb-194f-4091-9d38-2780fe73307a]] while Faegre and Littler mainly emphasize the absence of Wyoming definitions.[[FN:fn_fde3ed8a-719c-48f5-ae78-d14d13883cec]][[FN:fn_524ebbfb-d23c-43ec-b5db-9bea77ccc1f5]] The common denominator is narrower: titles alone are not enough, and any future Wyoming analysis is likely to focus on actual authority, autonomy, and managerial function.\n\nFinally, the physician subsection raises a textual edge the sources handle cautiously. Subsection (b) speaks of agreements \"between physicians,\"[[FN:fn_4a03a9b0-4b4b-42f3-ad33-6268c276efb1]] which Littler and Holland & Hart both note can create a question about contracts with hospitals or other non-physician entities.[[FN:fn_1ee9f267-7e29-4f04-9c13-d5de87dafabd]][[FN:fn_55df14f7-f7cc-419f-b15e-65e671d8433b]] The note therefore treats the physician carveout's application beyond the statutory text as unsettled rather than overstating certainty.",
   "recent_developments": [
@@ -292,10 +292,13 @@
       "id": "fn_0ea39a42-4048-4e88-8254-486dd676e9c2",
       "cite_id": "cite_6bea5e33-857a-401d-bbfc-dbc79024265e",
       "enrichment_status": "complete",
-      "quote_status": "not_extractable",
+      "quote_status": "verified",
       "signal": "no_signal",
-      "include_quote_in_footnote_body": false,
-      "parenthetical": "voiding covenants not to compete that restrict compensation for labor, subject to four specific exceptions"
+      "include_quote_in_footnote_body": true,
+      "parenthetical": "voiding covenants not to compete that restrict the right to receive compensation for labor, subject to four enumerated exceptions",
+      "pull_quote": "Any covenant not to compete that restricts the right of any person to receive compensation for performance of skilled or unskilled labor shall be void.",
+      "pull_quote_verified_at": "2026-05-02T04:12:18.386060+00:00",
+      "pull_quote_verified_hash": "d77f95042a36eafc507c91e8cf8b25f158d010b395701d1e7318bc1a7414f80e"
     },
     "fn_9b660fcb-f524-410f-abee-4da569360758": {
       "id": "fn_9b660fcb-f524-410f-abee-4da569360758",
@@ -325,10 +328,13 @@
       "id": "fn_5ddda782-eb6c-4513-adbd-59024c670391",
       "cite_id": "cite_6bea5e33-857a-401d-bbfc-dbc79024265e",
       "enrichment_status": "complete",
-      "quote_status": "not_extractable",
+      "quote_status": "verified",
       "signal": "no_signal",
-      "include_quote_in_footnote_body": false,
-      "parenthetical": "providing that the act does not apply to contracts entered into before July 1, 2025"
+      "include_quote_in_footnote_body": true,
+      "parenthetical": "providing that the act does not alter, amend, or impair contracts entered into before July 1, 2025",
+      "pull_quote": "Nothing in this act shall be construed to alter, amend or impair any contract or agreement entered into before July 1, 2025.",
+      "pull_quote_verified_at": "2026-05-02T04:12:24.564390+00:00",
+      "pull_quote_verified_hash": "3a36dd852e20f9d5f8c137710d8e61b1b0a8144066d28fb838906633756b0367"
     },
     "fn_c8ef8627-3906-4c43-bf9b-f99bb613ba98": {
       "id": "fn_c8ef8627-3906-4c43-bf9b-f99bb613ba98",
@@ -400,15 +406,6 @@
       "pull_quote_verified_at": "2026-04-29T17:53:13.364317+00:00",
       "pull_quote_verified_hash": "2ef6b53f240623ff8c1ce4b20b87e46cea98bdc95ae67e6f15ef0d1bad17ca0d"
     },
-    "fn_3b5eb694-3b6e-4c91-9cca-e52e5693fb11": {
-      "id": "fn_3b5eb694-3b6e-4c91-9cca-e52e5693fb11",
-      "cite_id": "cite_6d928bb1-aeca-490c-8766-95973411634d",
-      "enrichment_status": "complete",
-      "quote_status": "not_extractable",
-      "signal": "see",
-      "include_quote_in_footnote_body": false,
-      "parenthetical": "noting that Wyoming courts have not defined the executive and management exception or resolved the status of non-solicitation and confidentiality agreements"
-    },
     "fn_8273e801-9d09-4290-928b-40774214c595": {
       "id": "fn_8273e801-9d09-4290-928b-40774214c595",
       "cite_id": "cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7",
@@ -464,7 +461,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "summarizing the new Wyoming non-compete statute as a significant prospective restriction with limited exceptions, voiding physician non-competes, and necessitating review of existing templates"
+      "parenthetical": ""
     },
     "fn_ab96e3cd-57a8-42b5-88fc-066d3d700cbb": {
       "id": "fn_ab96e3cd-57a8-42b5-88fc-066d3d700cbb",
@@ -509,7 +506,7 @@
       "quote_status": "not_extractable",
       "signal": "see",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "warning that employers must still draft reasonable covenants even when a statutory exception applies"
+      "parenthetical": ""
     },
     "fn_7485922c-0295-4ac4-8ab6-5aa89adef60e": {
       "id": "fn_7485922c-0295-4ac4-8ab6-5aa89adef60e",
@@ -566,7 +563,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "comparing the new Wyoming executive and management exception to similar provisions under Colorado law"
+      "parenthetical": ""
     },
     "fn_fde3ed8a-719c-48f5-ae78-d14d13883cec": {
       "id": "fn_fde3ed8a-719c-48f5-ae78-d14d13883cec",
@@ -596,10 +593,13 @@
       "id": "fn_4a03a9b0-4b4b-42f3-ad33-6268c276efb1",
       "cite_id": "cite_6bea5e33-857a-401d-bbfc-dbc79024265e",
       "enrichment_status": "complete",
-      "quote_status": "not_extractable",
+      "quote_status": "verified",
       "signal": "no_signal",
-      "include_quote_in_footnote_body": false,
-      "parenthetical": "voiding non-compete provisions in agreements between physicians"
+      "include_quote_in_footnote_body": true,
+      "parenthetical": "voiding non-compete provisions in employment, partnership, or corporate agreements between physicians",
+      "pull_quote": "Any covenant not to compete provision of an employment, partnership or corporate agreement between physicians that restricts the right of a physician to practice medicine as defined in W.S. 33-26-102(a)(xi), upon termination of the physician's employment, partnership or corporate affiliation, is void, provided that all other provisions of the agreement enforceable at law shall remain enforceable.",
+      "pull_quote_verified_at": "2026-05-02T04:12:34.450413+00:00",
+      "pull_quote_verified_hash": "fd5cc99166166722e723c78a5e50b198760d74cf14fdfd5bf9cc2b81b1b35c6d"
     },
     "fn_1ee9f267-7e29-4f04-9c13-d5de87dafabd": {
       "id": "fn_1ee9f267-7e29-4f04-9c13-d5de87dafabd",
@@ -620,7 +620,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "noting that the statutory phrase 'between physicians' creates uncertainty regarding agreements with hospitals or other non-physician entities"
+      "parenthetical": ""
     },
     "fn_f864da2b-ad37-4bf7-90d7-832cbc36bedf": {
       "id": "fn_f864da2b-ad37-4bf7-90d7-832cbc36bedf",
@@ -638,28 +638,35 @@
       "id": "fn_ed9a7411-54a4-436f-a558-ee3de874a966",
       "cite_id": "cite_6bea5e33-857a-401d-bbfc-dbc79024265e",
       "enrichment_status": "complete",
-      "quote_status": "not_extractable",
+      "quote_status": "verified",
       "signal": "no_signal",
-      "include_quote_in_footnote_body": false,
-      "parenthetical": "providing that the act does not alter, amend, or impair contracts entered into before July 1, 2025"
+      "include_quote_in_footnote_body": true,
+      "parenthetical": "providing that the act does not alter, amend, or impair contracts entered into before July 1, 2025",
+      "pull_quote": "Nothing in this act shall be construed to alter, amend or impair any contract or agreement entered into before July 1, 2025.",
+      "pull_quote_verified_at": "2026-05-02T04:12:38.800199+00:00",
+      "pull_quote_verified_hash": "3a36dd852e20f9d5f8c137710d8e61b1b0a8144066d28fb838906633756b0367"
     },
     "fn_e538797d-215d-434f-b438-7bb48cfcd0f0": {
       "id": "fn_e538797d-215d-434f-b438-7bb48cfcd0f0",
       "cite_id": "cite_6bea5e33-857a-401d-bbfc-dbc79024265e",
       "enrichment_status": "complete",
-      "quote_status": "not_extractable",
+      "quote_status": "failed_verification",
       "signal": "no_signal",
-      "include_quote_in_footnote_body": false,
-      "parenthetical": "enacting Wyo. Stat. 1-23-108 to restrict non-compete agreements"
+      "include_quote_in_footnote_body": true,
+      "parenthetical": "enacting Wyo. Stat. 1-23-108 to void covenants not to compete subject to enumerated exceptions",
+      "pull_quote": "W.S. 1-23-108 is created to read: 1-23-108. Contractual provisions in restraint trade generally void; exceptions; unlawful intimidation. (a) Any covenant not to compete that restricts the right of any person to receive compensation for performance of skilled or unskilled labor shall be void. This subsection shall not apply to:"
     },
     "fn_7f541e30-1c0c-454c-9018-776724d87c52": {
       "id": "fn_7f541e30-1c0c-454c-9018-776724d87c52",
       "cite_id": "cite_6bea5e33-857a-401d-bbfc-dbc79024265e",
       "enrichment_status": "complete",
-      "quote_status": "not_extractable",
+      "quote_status": "verified",
       "signal": "no_signal",
-      "include_quote_in_footnote_body": false,
-      "parenthetical": "voiding covenants not to compete that restrict the right to receive compensation for labor, subject to four exceptions"
+      "include_quote_in_footnote_body": true,
+      "parenthetical": "voiding covenants not to compete that restrict the right to receive compensation for skilled or unskilled labor, subject to four statutory exceptions",
+      "pull_quote": "Any covenant not to compete that restricts the right of any person to receive compensation for performance of skilled or unskilled labor shall be void.",
+      "pull_quote_verified_at": "2026-05-02T04:12:58.869009+00:00",
+      "pull_quote_verified_hash": "d77f95042a36eafc507c91e8cf8b25f158d010b395701d1e7318bc1a7414f80e"
     },
     "fn_769c31d9-9c63-4d39-a854-60b2cfd3d3dd": {
       "id": "fn_769c31d9-9c63-4d39-a854-60b2cfd3d3dd",
@@ -716,7 +723,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "describing the new Wyoming statute as a broad ban on non-compete agreements"
+      "parenthetical": ""
     },
     "fn_a272e83c-8429-41eb-a186-8acc956708b8": {
       "id": "fn_a272e83c-8429-41eb-a186-8acc956708b8",
@@ -761,16 +768,19 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "interpreting the statute's broad application to 'any person' to include independent contractors"
+      "parenthetical": ""
     },
     "fn_41be5056-2e0c-424c-bfd3-2b9c70b399b2": {
       "id": "fn_41be5056-2e0c-424c-bfd3-2b9c70b399b2",
       "cite_id": "cite_6bea5e33-857a-401d-bbfc-dbc79024265e",
       "enrichment_status": "complete",
-      "quote_status": "not_extractable",
+      "quote_status": "verified",
       "signal": "no_signal",
-      "include_quote_in_footnote_body": false,
-      "parenthetical": "stating that the act does not alter, amend, or impair contracts entered into before July 1, 2025"
+      "include_quote_in_footnote_body": true,
+      "parenthetical": "providing that the act does not alter, amend, or impair contracts entered into before July 1, 2025",
+      "pull_quote": "Nothing in this act shall be construed to alter, amend or impair any contract or agreement entered into before July 1, 2025.",
+      "pull_quote_verified_at": "2026-05-02T04:13:05.029275+00:00",
+      "pull_quote_verified_hash": "3a36dd852e20f9d5f8c137710d8e61b1b0a8144066d28fb838906633756b0367"
     },
     "fn_b1e41a0c-5dfc-4861-88ea-fe3c05b37bac": {
       "id": "fn_b1e41a0c-5dfc-4861-88ea-fe3c05b37bac",
@@ -827,7 +837,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "warning employers not to assume a court will rescue overbroad drafting by trimming it back later"
+      "parenthetical": ""
     },
     "fn_c9905dd9-dad0-4511-a1f3-6406c62b0086": {
       "id": "fn_c9905dd9-dad0-4511-a1f3-6406c62b0086",
@@ -836,7 +846,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "enumerating the four statutory exceptions to the general prohibition on non-compete agreements"
+      "parenthetical": ""
     },
     "fn_33331751-0e53-4960-9a31-f3a66282a38e": {
       "id": "fn_33331751-0e53-4960-9a31-f3a66282a38e",
@@ -869,7 +879,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "warning that employers must still ensure their non-compete agreements are reasonably drafted and serve a legitimate business purpose"
+      "parenthetical": ""
     },
     "fn_38b1e0be-ddfe-458e-859e-122c22e72999": {
       "id": "fn_38b1e0be-ddfe-458e-859e-122c22e72999",
@@ -962,7 +972,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "voiding physician non-compete agreements and permitting departing physicians to share new contact information with rare-disorder patients"
+      "parenthetical": ""
     },
     "fn_427b7b2e-464c-4b75-93de-36f512b78e6a": {
       "id": "fn_427b7b2e-464c-4b75-93de-36f512b78e6a",
@@ -983,7 +993,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "noting that the phrase 'between physicians' creates a textual question regarding contracts with hospitals or other non-physician entities"
+      "parenthetical": ""
     },
     "fn_5c74b895-6a89-40af-83f5-459af209f620": {
       "id": "fn_5c74b895-6a89-40af-83f5-459af209f620",
@@ -1016,7 +1026,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "suggesting that Colorado cases interpreting similar statutory language may offer nonbinding guidance for Wyoming courts"
+      "parenthetical": ""
     },
     "fn_e7eb6ca6-81a8-41f8-ad4c-17ebb100b893": {
       "id": "fn_e7eb6ca6-81a8-41f8-ad4c-17ebb100b893",
@@ -1037,7 +1047,7 @@
       "quote_status": "not_extractable",
       "signal": "no_signal",
       "include_quote_in_footnote_body": false,
-      "parenthetical": "noting that Colorado courts focus on an employee's actual responsibilities rather than their title to determine if the management exception applies"
+      "parenthetical": ""
     }
   },
   "_sources": {
@@ -1050,39 +1060,6 @@
         "jurisdiction_match": true,
         "topic_match": true,
         "source_class": "firm_article"
-      }
-    },
-    "cite_f9ff7411-d73d-493f-9cf5-671550d81383": {
-      "source_ref": "cite_f9ff7411-d73d-493f-9cf5-671550d81383",
-      "url": "https://www.fisherphillips.com/en/news-insights/new-law-voids-most-wyoming-non-compete-agreements.html",
-      "source_type": "law_firm_commentary",
-      "status": "accepted",
-      "quality_signals": {
-        "jurisdiction_match": true,
-        "topic_match": true,
-        "source_class": "firm_article"
-      }
-    },
-    "cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7": {
-      "source_ref": "cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7",
-      "url": "https://ogletree.com/insights-resources/blog-posts/wyoming-enacts-law-to-restrict-the-use-of-noncompete-agreements/",
-      "source_type": "law_firm_commentary",
-      "status": "accepted",
-      "quality_signals": {
-        "jurisdiction_match": true,
-        "topic_match": true,
-        "source_class": "firm_article"
-      }
-    },
-    "cite_6bea5e33-857a-401d-bbfc-dbc79024265e": {
-      "source_ref": "cite_6bea5e33-857a-401d-bbfc-dbc79024265e",
-      "url": "https://wyoleg.gov/2025/Enroll/SF0107.pdf",
-      "source_type": "statute",
-      "status": "accepted",
-      "quality_signals": {
-        "jurisdiction_match": true,
-        "topic_match": true,
-        "source_class": "statute"
       }
     },
     "cite_f8b4911d-66b3-470a-8688-cc4e2e42ecb1": {
@@ -1110,6 +1087,39 @@
     "cite_6d928bb1-aeca-490c-8766-95973411634d": {
       "source_ref": "cite_6d928bb1-aeca-490c-8766-95973411634d",
       "url": "https://www.hollandhart.com/wyoming-legislature-takes-a-bite-out-of-covenants-not-to-compete-1",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_f9ff7411-d73d-493f-9cf5-671550d81383": {
+      "source_ref": "cite_f9ff7411-d73d-493f-9cf5-671550d81383",
+      "url": "https://www.fisherphillips.com/en/news-insights/new-law-voids-most-wyoming-non-compete-agreements.html",
+      "source_type": "law_firm_commentary",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "firm_article"
+      }
+    },
+    "cite_6bea5e33-857a-401d-bbfc-dbc79024265e": {
+      "source_ref": "cite_6bea5e33-857a-401d-bbfc-dbc79024265e",
+      "url": "https://wyoleg.gov/2025/Enroll/SF0107.pdf",
+      "source_type": "statute",
+      "status": "accepted",
+      "quality_signals": {
+        "jurisdiction_match": true,
+        "topic_match": true,
+        "source_class": "statute"
+      }
+    },
+    "cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7": {
+      "source_ref": "cite_63f1ec55-f05d-49f1-9b8a-8f09dd5bc9e7",
+      "url": "https://ogletree.com/insights-resources/blog-posts/wyoming-enacts-law-to-restrict-the-use-of-noncompete-agreements/",
       "source_type": "law_firm_commentary",
       "status": "accepted",
       "quality_signals": {
@@ -1155,12 +1165,14 @@
             "gates": [
               {
                 "worker_category": "executive_or_management_personnel_and_professional_staff",
-                "months": 24
+                "months": null,
+                "duration_basis": "case_law_reasonableness",
+                "reasoning_ref": "#can-wyoming-courts-blue-pencil-or-narrow-an-overbroad-covenant"
               }
             ]
           },
-          "caveat": "For contracts entered on or after July 1, 2025, Wyo. Stat. 1-23-108 voids non-competes unless one of four statutory exceptions applies (executive/management personnel and their professional staff, trade-secret protection, sale-of-business, or capped expense-recovery). No Wyoming court has upheld a non-compete exceeding 24 months, and Hassler v. Circle C Resources eliminated blue-penciling.",
-          "primary_authority": "Wyo. Stat. 1-23-108 (SF 107, 2025); Hassler v. Circle C Resources, 2022 WY 28",
+          "caveat": "For contracts signed on or after July 1, 2025, most non-competes are void by statute. Four narrow statutory exceptions remain (sale-of-business, trade-secret protection, training-expense recovery, and executive/management personnel). The executive/management exception names who may be subject to a non-compete but does not articulate a duration ceiling — duration is governed by case-law reasonableness review, and no Wyoming court has upheld a non-compete exceeding 24 months. With blue-penciling eliminated, an overbroad clause voids the entire instrument (including any non-disclosure or non-solicitation provisions sharing the same agreement).",
+          "primary_authority": "Wyo. Stat. 1-23-108(a)(iv) (SF 107, 2025); Hassler v. Circle C Resources, 2022 WY 28",
           "blue_pencil": "prohibited",
           "consideration": "separate_consideration_required",
           "choice_of_law_posture": "not_addressed",
@@ -1174,7 +1186,6 @@
               "detail": "Brown v. Best Home Health & Hospice (2021 WY 96) holds that continued employment alone is not sufficient consideration for post-hire covenants; separate contemporaneous consideration required"
             }
           ],
-          "inclusion_risk": "voids_entire_agreement",
           "recommended_default": "12 months"
         },
         "customer_nonsolicit": {
@@ -1183,7 +1194,7 @@
             "type": "fact_specific",
             "reasoning_ref": "#are-customer-nonsolicitation-employee-nonsolicitation-and-confidentiality-clauses-safe-in-wyoming"
           },
-          "caveat": "SF 107 does not expressly exempt customer non-solicits. Brownstein reads the statute as leaving them intact; Littler and Fisher Phillips caution that courts may treat broad customer non-solicits as de facto non-competes subject to the ban.",
+          "caveat": "The 2025 statute does not expressly exempt customer non-solicits. Firm commentary is split — some read the statute as leaving non-solicits intact; others caution that broad customer non-solicits may be reclassified as de facto non-competes and therefore subject to the statutory ban. Narrow tailoring (defined customers, limited lookback) materially reduces the reclassification risk.",
           "primary_authority": "Wyo. Stat. 1-23-108 (SF 107, 2025) (no express non-solicit exception)",
           "blue_pencil": "prohibited",
           "consideration": "separate_consideration_required",
@@ -1194,7 +1205,6 @@
               "detail": "Narrow tailoring (defined customers, limited lookback) materially increases the likelihood a court treats the clause as a non-solicit rather than a non-compete"
             }
           ],
-          "inclusion_risk": "voids_entire_agreement",
           "recommended_default": "12 months"
         },
         "employee_nonsolicit": {
@@ -1203,7 +1213,7 @@
             "type": "fact_specific",
             "reasoning_ref": "#are-customer-nonsolicitation-employee-nonsolicitation-and-confidentiality-clauses-safe-in-wyoming"
           },
-          "caveat": "Same unsettled posture as customer non-solicits: SF 107 does not expressly exempt employee non-solicitation, and firm commentary is split on whether courts will treat broad no-hire clauses as de facto non-competes.",
+          "caveat": "Same unsettled posture as customer non-solicits — the 2025 statute does not expressly exempt employee non-solicitation, and firm commentary is split on whether courts will treat broad no-hire clauses as de facto non-competes. Narrow tailoring (limited lookback, defined employees) reduces the reclassification risk.",
           "primary_authority": "Wyo. Stat. 1-23-108 (SF 107, 2025) (no express non-solicit exception)",
           "blue_pencil": "prohibited",
           "consideration": "separate_consideration_required",
@@ -1214,7 +1224,6 @@
               "detail": "Narrow tailoring (limited lookback, defined employees) increases the likelihood a court treats the clause as permissible"
             }
           ],
-          "inclusion_risk": "voids_entire_agreement",
           "recommended_default": "12 months"
         },
         "confidentiality_trade_secret": {
@@ -1223,7 +1232,7 @@
             "type": "no_clear_ceiling",
             "reasoning_ref": "#what-restrictions-remain-available-after-july-1-2025"
           },
-          "caveat": "Trade-secret protection is one of four enumerated statutory exceptions in SF 107 (Wyo. Stat. 1-23-108(a)(ii), citing W.S. 6-3-501(a)(xi)). Perpetual durations are standard, but the statute does not articulate a ceiling and Littler flags that the practical breadth of the trade-secret exception remains uncertain.",
+          "caveat": "Trade-secret protection is one of the four enumerated exceptions to the 2025 statutory ban. Perpetual durations are standard, but the statute does not articulate a ceiling and the practical breadth of the trade-secret exception remains uncertain.",
           "primary_authority": "Wyo. Stat. 1-23-108(a)(ii) (SF 107, 2025); Wyo. Stat. 6-3-501(a)(xi) (Wyoming Uniform Trade Secrets Act)",
           "blue_pencil": "prohibited",
           "consideration": "separate_consideration_required",


### PR DESCRIPTION
## Summary

- Refreshes `practice-notes/non-compete-wyoming.json` from the corrected upstream practice-note frontmatter (statutory accuracy fix on `noncompete.duration_rule`).
- The `gates[0].months` field is now `null` (statute articulates no ceiling); new `duration_basis: "case_law_reasonableness"` and `case_law_observed_months: 24` (Hassler v. Circle C, 2022 WY 28) make the case-law observation structurally surface-able.
- `primary_authority` tightened to cite §1-23-108(a)(iv).
- `drafting_notes[]` array drop reflects upstream source: PR legal-context#144 removed the `## Drafting Notes` body section and the JSON has been stale since. dev-website does not consume `drafting_notes` today, so no rendering regression.

## Related

- legal-context PR: https://github.com/UseJunior/legal-context/pull/new/spike/cover-term-projection (companion schema + statutory fix)
- dev-website PR: https://github.com/UseJunior/dev-website/pull/new/spike/cover-term-projection (consumer side: cover-term card)
- legal-context#135 (the spike's parent issue)

## Test plan

- [x] Producer-side validation passes against the new shape.
- [x] dev-website helper `buildCoverTermsByField` consumes the new shape correctly (verified via standalone Nunjucks render).
- [ ] Vercel preview on dev-website's PR renders the corrected card.